### PR TITLE
Hotfix/queryruns

### DIFF
--- a/examples/query_run.py
+++ b/examples/query_run.py
@@ -1,325 +1,290 @@
 #!/usr/bin/env python3
 """
-Query Run Management Example
+Query Run Individual Function Tests
 
-This example demonstrates all available query run operations in the Python TFE SDK,
-including create, read, list, logs, cancel, and force cancel operations.
+This file provides individual test functions for each query run operation.
+You can run specific functions to test individual parts of the API.
+
+Functions available:
+- test_list() - List query runs in a workspace
+- test_create() - Create a new query run
+- test_read() - Read a specific query run
+- test_logs() - Retrieve logs for a query run
+- test_cancel() - Cancel a query run
+- test_force_cancel() - Force cancel a query run
 
 Usage:
-    python examples/query_run.py
-
-Requirements:
-    - TFE_TOKEN environment variable set
-    - TFE_WORKSPACE_ID environment variable set
-    - TFE_ADDRESS environment variable set (optional, defaults to Terraform Cloud)
-    - An existing workspace in your Terraform Cloud/Enterprise instance
-
-Query Run Operations Demonstrated:
-    1. List query runs for a workspace
-    2. Create new query runs
-    3. Read query run details
-    4. Read query run with additional options
-    5. Retrieve query run logs
-    6. Cancel running query runs
-    7. Force cancel stuck query runs
+    python query_run.py
+    
+Note: Query Runs require Terraform 1.10+ which includes the 'terraform query' command.
+      These tests may fail with error status since the feature is not fully available yet.
 """
 
 import os
 import time
-from datetime import datetime
 
 from pytfe import TFEClient, TFEConfig
 from pytfe.models import (
     QueryRunCreateOptions,
-    QueryRunIncludeOpt,
     QueryRunListOptions,
-    QueryRunReadOptions,
     QueryRunSource,
-    QueryRunStatus,
 )
 
 
-def test_list_query_runs(client, workspace_id):
-    """Test listing query runs with various options."""
-    print("=== Testing Query Run List Operations ===")
+def get_client_and_workspace():
+    """Initialize client and get workspace ID."""
+    client = TFEClient(TFEConfig.from_env())
+    organization = os.getenv("TFE_ORG", "aayush-test")
+    workspace_name = "query-test"  # Default workspace for testing
+    
+    # Get workspace
+    workspace = client.workspaces.read(workspace_name, organization=organization)
+    return client, workspace
 
-    # 1. List all query runs
-    print("\n1. Listing All Query Runs:")
+
+def test_list():
+    """Test 1: List query runs in a workspace."""
+    print("=== Test 1: List Query Runs ===")
+    
+    client, workspace = get_client_and_workspace()
+    
     try:
-        query_runs = client.query_runs.list(workspace_id)
-        print(f"   SUCCESS: Found {len(query_runs.items)} query runs")
-        if query_runs.items:
-            print(f"   SUCCESS: Latest query run: {query_runs.items[0].id}")
-            print(f"   SUCCESS: Status: {query_runs.items[0].status}")
-            print(f"   SUCCESS: Source: {query_runs.items[0].source}")
+        # Simple list
+        query_runs = list(client.query_runs.list(workspace.id))
+        print(f"Found {len(query_runs)} query runs in workspace '{workspace.name}'")
+        
+        for i, qr in enumerate(query_runs[:5], 1):
+            print(f"  {i}. {qr.id}")
+            print(f"     Status: {qr.status}")
+            print(f"     Created: {qr.created_at}")
+            print()
+        
+        # List with options
+        options = QueryRunListOptions(page_size=5)
+        limited_runs = list(client.query_runs.list(workspace.id, options))
+        print(f"Retrieved {len(limited_runs)} query runs (page_size=5)")
+        
+        return query_runs
+        
     except Exception as e:
-        print(f"   ERROR: Error: {e}")
+        print(f"Error: {e}")
+        return []
 
-    # 2. List with pagination
-    print("\n2. Listing Query Runs with Pagination:")
+
+def test_create():
+    """Test 2: Create a new query run."""
+    print("\n=== Test 2: Create Query Run ===")
+    
+    client, workspace = get_client_and_workspace()
+    
     try:
-        options = QueryRunListOptions(page_number=1, page_size=5)
-        query_runs = client.query_runs.list(workspace_id, options)
-        print(f"   SUCCESS: Page 1 has {len(query_runs.items)} query runs")
-        print(f"   SUCCESS: Total pages: {query_runs.total_pages}")
-        print(f"   SUCCESS: Total count: {query_runs.total_count}")
-    except Exception as e:
-        print(f"   ERROR: Error: {e}")
-
-    # 3. List with include options
-    print("\n3. Listing Query Runs with Related Resources:")
-    try:
-        options = QueryRunListOptions(
-            page_size=10,
-            include=[QueryRunIncludeOpt.CREATED_BY]
-        )
-        query_runs = client.query_runs.list(workspace_id, options)
-        print(f"   SUCCESS: Found {len(query_runs.items)} query runs with created_by info")
-        for qr in query_runs.items[:3]:  # Show first 3
-            print(f"     - {qr.id}: Status={qr.status}")
-    except Exception as e:
-        print(f"   ERROR: Error: {e}")
-
-    return query_runs.items[0] if query_runs.items else None
-
-
-def test_create_query_run(client, workspace_id):
-    """Test creating a query run."""
-    print("\n=== Testing Query Run Creation ===")
-
-    # Create a query run
-    print("\n1. Creating Query Run:")
-    try:
+        # Get the latest configuration version
+        config_versions = list(client.configuration_versions.list(workspace.id))
+        if not config_versions:
+            print("ERROR: No configuration versions found in workspace")
+            return None
+        
+        config_version = config_versions[0]
+        print(f"Using configuration version: {config_version.id}")
+        
+        # Create query run
         options = QueryRunCreateOptions(
             source=QueryRunSource.API,
-            workspace_id=workspace_id,
+            workspace_id=workspace.id,
+            configuration_version_id=config_version.id,
         )
+        
         query_run = client.query_runs.create(options)
-        print(f"   SUCCESS: Created query run: {query_run.id}")
-        print(f"   SUCCESS: Status: {query_run.status}")
-        print(f"   SUCCESS: Source: {query_run.source}")
-        print(f"   SUCCESS: Created at: {query_run.created_at}")
+        print(f"Created query run: {query_run.id}")
+        print(f"  Status: {query_run.status}")
+        print(f"  Source: {query_run.source}")
+        print(f"  Created: {query_run.created_at}")
+        
         return query_run
-    except Exception as e:
-        print(f"   ERROR: Error: {e}")
-        return None
-
-
-def test_read_query_run(client, query_run_id):
-    """Test reading query run details."""
-    print(f"\n=== Testing Query Run Read Operations for {query_run_id} ===")
-
-    # 1. Basic read
-    print("\n1. Reading Query Run Details:")
-    try:
-        query_run = client.query_runs.read(query_run_id)
-        print(f"   SUCCESS: Query Run ID: {query_run.id}")
-        print(f"   SUCCESS: Status: {query_run.status}")
-        print(f"   SUCCESS: Source: {query_run.source}")
-        print(f"   SUCCESS: Created: {query_run.created_at}")
-        print(f"   SUCCESS: Updated: {query_run.updated_at}")
-        if query_run.actions:
-            print(f"   SUCCESS: Is Cancelable: {query_run.actions.is_cancelable}")
-            print(f"   SUCCESS: Is Force Cancelable: {query_run.actions.is_force_cancelable}")
-        if query_run.log_read_url:
-            print(f"   SUCCESS: Log URL available")
-    except Exception as e:
-        print(f"   ERROR: Error: {e}")
-        return None
-
-    # 2. Read with options
-    print("\n2. Reading Query Run with Options:")
-    try:
-        options = QueryRunReadOptions(
-            include=[QueryRunIncludeOpt.CREATED_BY, QueryRunIncludeOpt.CONFIGURATION_VERSION]
-        )
-        query_run = client.query_runs.read_with_options(query_run_id, options)
-        print("   SUCCESS: Read query run with additional data")
-        print(f"   SUCCESS: Status: {query_run.status}")
-    except Exception as e:
-        print(f"   ERROR: Error: {e}")
-
-    return query_run
-
-
-def test_query_run_logs(client, query_run_id):
-    """Test retrieving query run logs."""
-    print(f"\n=== Testing Query Run Logs for {query_run_id} ===")
-
-    try:
-        logs_stream = client.query_runs.logs(query_run_id)
-        log_content = logs_stream.read()
         
-        if isinstance(log_content, bytes):
-            log_text = log_content.decode('utf-8')
-        else:
-            log_text = log_content
-            
-        print(f"   SUCCESS: Retrieved logs for query run")
-        print(f"   SUCCESS: Log size: {len(log_text)} characters")
-
-        # Show first few lines of logs
-        log_lines = log_text.split("\n")[:5]
-        print("   SUCCESS: Log preview:")
-        for line in log_lines:
-            if line.strip():
-                print(f"     {line}")
     except Exception as e:
-        print(f"   ERROR: Error retrieving logs: {e}")
+        print(f"Error: {e}")
+        return None
 
 
-def test_query_run_cancellation(client, query_run_id):
-    """Test canceling query runs."""
-    print(f"\n=== Testing Query Run Cancellation for {query_run_id} ===")
-
-    # First check if the query run is in a cancelable state
+def test_read(query_run_id=None):
+    """Test 3: Read a specific query run."""
+    print("\n=== Test 3: Read Query Run ===")
+    
+    client, workspace = get_client_and_workspace()
+    
     try:
+        # If no query_run_id provided, get the first one from the list
+        if not query_run_id:
+            query_runs = list(client.query_runs.list(workspace.id))
+            if not query_runs:
+                print("ERROR: No query runs found to read")
+                return None
+            query_run_id = query_runs[0].id
+            print(f"Using first query run from list: {query_run_id}")
+        
+        # Read the query run
         query_run = client.query_runs.read(query_run_id)
-        if query_run.status not in [QueryRunStatus.PENDING, QueryRunStatus.QUEUED, QueryRunStatus.RUNNING]:
-            print(
-                f"   INFO: Query run is {query_run.status}, not in a cancelable state"
-            )
-            return
-            
-        if not query_run.actions or not query_run.actions.is_cancelable:
-            print(f"   INFO: Query run is not cancelable")
-            return
+        print(f"Read query run: {query_run.id}")
+        print(f"  Status: {query_run.status}")
+        print(f"  Source: {query_run.source}")
+        print(f"  Created: {query_run.created_at}")
+        
+        if query_run.status_timestamps:
+            print(f"  Status Timestamps:")
+            if query_run.status_timestamps.queued_at:
+                print(f"    Queued: {query_run.status_timestamps.queued_at}")
+            if query_run.status_timestamps.running_at:
+                print(f"    Running: {query_run.status_timestamps.running_at}")
+            if query_run.status_timestamps.finished_at:
+                print(f"    Finished: {query_run.status_timestamps.finished_at}")
+            if query_run.status_timestamps.errored_at:
+                print(f"    Errored: {query_run.status_timestamps.errored_at}")
+        
+        return query_run
+        
     except Exception as e:
-        print(f"   ERROR: Error checking query run status: {e}")
-        return
+        print(f"Error: {e}")
+        return None
 
-    # Test regular cancel
-    print("\n1. Testing Regular Cancellation:")
+
+def test_logs(query_run_id=None):
+    """Test 4: Retrieve logs for a query run."""
+    print("\n=== Test 4: Get Query Run Logs ===")
+    
+    client, workspace = get_client_and_workspace()
+    
     try:
+        # If no query_run_id provided, get the first one from the list
+        if not query_run_id:
+            query_runs = list(client.query_runs.list(workspace.id))
+            if not query_runs:
+                print("ERROR: No query runs found to get logs")
+                return None
+            query_run_id = query_runs[0].id
+            print(f"Using first query run from list: {query_run_id}")
+        
+        # Get logs
+        logs = client.query_runs.logs(query_run_id)
+        log_content = logs.read().decode("utf-8")
+        
+        print(f"Retrieved logs for query run: {query_run_id}")
+        print(f"  Log size: {len(log_content)} bytes")
+        print(f"\n--- Log Preview (first 500 chars) ---")
+        print(log_content[:500])
+        if len(log_content) > 500:
+            print(f"\n... ({len(log_content) - 500} more characters)")
+        print("--- End of Log Preview ---")
+        
+        return log_content
+        
+    except Exception as e:
+        print(f"Error: {e}")
+        print(f"  Note: Logs may not be available if the query run hasn't started yet")
+        return None
+
+
+def test_cancel(query_run_id=None):
+    """Test 5: Cancel a query run."""
+    print("\n=== Test 5: Cancel Query Run ===")
+    
+    client, workspace = get_client_and_workspace()
+    
+    try:
+        # If no query_run_id provided, create a new one
+        if not query_run_id:
+            print("Creating a new query run to cancel...")
+            new_run = test_create()
+            if not new_run:
+                print("ERROR: Could not create query run to cancel")
+                return False
+            query_run_id = new_run.id
+            time.sleep(1)  # Give it a moment to start
+        
+        # Cancel the query run
         client.query_runs.cancel(query_run_id)
-        print(f"   SUCCESS: Canceled query run: {query_run_id}")
+        print(f"Cancel requested for query run: {query_run_id}")
         
-        # Read to verify
+        # Verify cancellation
+        time.sleep(2)
         query_run = client.query_runs.read(query_run_id)
-        print(f"   SUCCESS: New status: {query_run.status}")
+        print(f"  Status after cancel: {query_run.status}")
+        
+        return True
+        
     except Exception as e:
-        print(f"   ERROR: Error canceling query run: {e}")
+        print(f"Error: {e}")
+        print(f"  Note: Query run may not be in a cancelable state")
+        return False
 
 
-def test_query_run_workflow(client, workspace_id):
-    """Test a complete query run workflow."""
-    print("\n=== Testing Complete Query Run Workflow ===")
-
-    # 1. Create a query run
-    print("\n1. Creating Query Run:")
+def test_force_cancel(query_run_id=None):
+    """Test 6: Force cancel a query run."""
+    print("\n=== Test 6: Force Cancel Query Run ===")
+    
+    client, workspace = get_client_and_workspace()
+    
     try:
-        options = QueryRunCreateOptions(
-            source=QueryRunSource.API,
-            workspace_id=workspace_id,
-        )
-        query_run = client.query_runs.create(options)
-        print(f"   SUCCESS: Created: {query_run.id}")
-        query_run_id = query_run.id
+        # If no query_run_id provided, create a new one
+        if not query_run_id:
+            print("Creating a new query run to force cancel...")
+            new_run = test_create()
+            if not new_run:
+                print("ERROR: Could not create query run to force cancel")
+                return False
+            query_run_id = new_run.id
+            time.sleep(1)  # Give it a moment to start
+        
+        # Force cancel the query run
+        client.query_runs.force_cancel(query_run_id)
+        print(f"Force cancel requested for query run: {query_run_id}")
+        
+        # Verify force cancellation
+        time.sleep(2)
+        query_run = client.query_runs.read(query_run_id)
+        print(f"  Status after force cancel: {query_run.status}")
+        
+        return True
+        
     except Exception as e:
-        print(f"   ERROR: Error creating query run: {e}")
-        return
-
-    # 2. Monitor execution
-    print("\n2. Monitoring Execution:")
-    max_attempts = 30
-    attempt = 0
-
-    while attempt < max_attempts:
-        try:
-            query_run = client.query_runs.read(query_run_id)
-            print(f"   Attempt {attempt + 1}: Status = {query_run.status}")
-
-            if query_run.status in [
-                QueryRunStatus.FINISHED,
-                QueryRunStatus.ERRORED,
-                QueryRunStatus.CANCELED,
-            ]:
-                break
-
-            time.sleep(2)  # Wait 2 seconds before checking again
-            attempt += 1
-        except Exception as e:
-            print(f"   ERROR: Error monitoring query run: {e}")
-            break
-
-    # 3. Get final logs if finished
-    print("\n3. Getting Final Status:")
-    try:
-        if query_run.status == QueryRunStatus.FINISHED:
-            print("   SUCCESS: Query completed successfully")
-            
-            # Get logs
-            if query_run.log_read_url:
-                logs_stream = client.query_runs.logs(query_run_id)
-                log_content = logs_stream.read()
-                print(f"   SUCCESS: Retrieved execution logs ({len(log_content)} bytes)")
-        else:
-            print(f"   ERROR: Query run finished with status: {query_run.status}")
-    except Exception as e:
-        print(f"   ERROR: Error getting final results: {e}")
-
-    return query_run_id
+        print(f"Error: {e}")
+        print(f"  Note: Query run may not be in a force-cancelable state")
+        return False
 
 
 def main():
-    """Main function to demonstrate query run operations."""
-    # Get configuration from environment
-    token = os.environ.get("TFE_TOKEN")
-    workspace_id = os.environ.get("TFE_WORKSPACE_ID")
-    address = os.environ.get("TFE_ADDRESS", "https://app.terraform.io")
-
-    if not token:
-        print("Error: TFE_TOKEN environment variable is required")
-        return 1
-
-    if not workspace_id:
-        print("Error: TFE_WORKSPACE_ID environment variable is required")
-        print("  Set it to the workspace ID where you want to run queries")
-        return 1
-
-    # Initialize client
-    print("=== Terraform Enterprise Query Run SDK Example ===")
-    print(f"Address: {address}")
-    print(f"Workspace ID: {workspace_id}")
-    print(f"Timestamp: {datetime.now()}")
-
-    config = TFEConfig(address=address, token=token)
-    client = TFEClient(config)
-
-    try:
-        # 1. List existing query runs
-        existing_query_run = test_list_query_runs(client, workspace_id)
-
-        # 2. Create a new query run
-        created_query_run = test_create_query_run(client, workspace_id)
-
-        # 3. Test read operations
-        if existing_query_run:
-            test_read_query_run(client, existing_query_run.id)
-
-            # Only test logs if query run is finished
-            if existing_query_run.status == QueryRunStatus.FINISHED:
-                test_query_run_logs(client, existing_query_run.id)
-
-        # 4. Test cancellation (if query run is cancelable)
-        if created_query_run:
-            test_query_run_cancellation(client, created_query_run.id)
-
-        # 5. Test complete workflow
-        test_query_run_workflow(client, workspace_id)
-
-        print("\n" + "=" * 80)
-        print("Query Run operations completed successfully!")
-        print("=" * 80)
-
-    except Exception as e:
-        print(f"\nUnexpected error: {e}")
-        import traceback
-        traceback.print_exc()
-        return 1
-
-    return 0
+    """Run all tests in sequence."""
+    print("=" * 80)
+    print("QUERY RUN FUNCTION TESTS")
+    print("=" * 80)
+    print("Testing all Query Run API operations")
+    print()
+    print("NOTE: Query Runs require Terraform 1.10+ with 'terraform query' command.")
+    print("      Most query runs will error since this feature is not yet available.")
+    print("=" * 80)
+    
+    # Test 1: List query runs
+    query_runs = test_list()
+    
+    # Test 2: Create a query run
+    new_query_run = test_create()
+    
+    # Test 3: Read a query run
+    if query_runs:
+        test_read(query_runs[0].id)
+    elif new_query_run:
+        test_read(new_query_run.id)
+    
+    # Test 4: Get logs (use first query run from list)
+    if query_runs:
+        test_logs(query_runs[0].id)
+    
+    # Test 5: Cancel a query run (creates new one)
+    test_cancel()
+    
+    # Test 6: Force cancel a query run (creates new one)
+    test_force_cancel()
 
 
 if __name__ == "__main__":
-    exit(main())
+    main()

--- a/examples/query_run.py
+++ b/examples/query_run.py
@@ -16,7 +16,7 @@ Functions available:
 Usage:
     python query_run.py
     
-Note: Query Runs require Terraform 1.10+ which includes the 'terraform query' command.
+Note: Query Runs require Terraform ~>1.14 which includes the 'terraform query' command.
       These tests may fail with error status since the feature is not fully available yet.
 """
 

--- a/examples/query_run.py
+++ b/examples/query_run.py
@@ -3,27 +3,25 @@
 Query Run Management Example
 
 This example demonstrates all available query run operations in the Python TFE SDK,
-including create, read, list, logs, results, cancel, and force cancel operations.
+including create, read, list, logs, cancel, and force cancel operations.
 
 Usage:
     python examples/query_run.py
 
 Requirements:
     - TFE_TOKEN environment variable set
-    - TFE_ADDRESS             # Get logs
-            logs = client.query_runs.logs(query_run_id)
-            print(f"   ✓ Retrieved execution logs ({len(logs.logs)} characters)")ironment variable set (optional, defaults to Terraform Cloud)
-    - An existing organization in your Terraform Cloud/Enterprise instance
+    - TFE_WORKSPACE_ID environment variable set
+    - TFE_ADDRESS environment variable set (optional, defaults to Terraform Cloud)
+    - An existing workspace in your Terraform Cloud/Enterprise instance
 
 Query Run Operations Demonstrated:
-    1. List query runs with various filters
-    2. Create new query runs with different types
+    1. List query runs for a workspace
+    2. Create new query runs
     3. Read query run details
     4. Read query run with additional options
     5. Retrieve query run logs
-    6. Retrieve query run results
-    7. Cancel running query runs
-    8. Force cancel stuck query runs
+    6. Cancel running query runs
+    7. Force cancel stuck query runs
 """
 
 import os
@@ -32,124 +30,79 @@ from datetime import datetime
 
 from pytfe import TFEClient, TFEConfig
 from pytfe.models import (
-    QueryRunCancelOptions,
     QueryRunCreateOptions,
-    QueryRunForceCancelOptions,
+    QueryRunIncludeOpt,
     QueryRunListOptions,
     QueryRunReadOptions,
+    QueryRunSource,
     QueryRunStatus,
-    QueryRunType,
 )
 
 
-def test_list_query_runs(client, organization_name):
+def test_list_query_runs(client, workspace_id):
     """Test listing query runs with various options."""
     print("=== Testing Query Run List Operations ===")
 
     # 1. List all query runs
     print("\n1. Listing All Query Runs:")
     try:
-        query_runs = client.query_runs.list(organization_name)
-        print(f"   ✓ Found {len(query_runs.items)} query runs")
+        query_runs = client.query_runs.list(workspace_id)
+        print(f"   SUCCESS: Found {len(query_runs.items)} query runs")
         if query_runs.items:
-            print(f"   ✓ Latest query run: {query_runs.items[0].id}")
-            print(f"   ✓ Status: {query_runs.items[0].status}")
-            print(f"   ✓ Query type: {query_runs.items[0].query_type}")
+            print(f"   SUCCESS: Latest query run: {query_runs.items[0].id}")
+            print(f"   SUCCESS: Status: {query_runs.items[0].status}")
+            print(f"   SUCCESS: Source: {query_runs.items[0].source}")
     except Exception as e:
-        print(f"   ✗ Error: {e}")
+        print(f"   ERROR: Error: {e}")
 
     # 2. List with pagination
     print("\n2. Listing Query Runs with Pagination:")
     try:
         options = QueryRunListOptions(page_number=1, page_size=5)
-        query_runs = client.query_runs.list(organization_name, options)
-        print(f"   ✓ Page 1 has {len(query_runs.items)} query runs")
-        print(f"   ✓ Total pages: {query_runs.total_pages}")
-        print(f"   ✓ Total count: {query_runs.total_count}")
+        query_runs = client.query_runs.list(workspace_id, options)
+        print(f"   SUCCESS: Page 1 has {len(query_runs.items)} query runs")
+        print(f"   SUCCESS: Total pages: {query_runs.total_pages}")
+        print(f"   SUCCESS: Total count: {query_runs.total_count}")
     except Exception as e:
-        print(f"   ✗ Error: {e}")
+        print(f"   ERROR: Error: {e}")
 
-    # 3. List with filters
-    print("\n3. Listing Query Runs with Filters:")
+    # 3. List with include options
+    print("\n3. Listing Query Runs with Related Resources:")
     try:
         options = QueryRunListOptions(
-            query_type=QueryRunType.FILTER,
-            status=QueryRunStatus.COMPLETED,
             page_size=10,
+            include=[QueryRunIncludeOpt.CREATED_BY]
         )
-        query_runs = client.query_runs.list(organization_name, options)
-        print(f"   ✓ Found {len(query_runs.items)} completed filter query runs")
+        query_runs = client.query_runs.list(workspace_id, options)
+        print(f"   SUCCESS: Found {len(query_runs.items)} query runs with created_by info")
         for qr in query_runs.items[:3]:  # Show first 3
-            print(f"     - {qr.id}: {qr.query[:50]}...")
+            print(f"     - {qr.id}: Status={qr.status}")
     except Exception as e:
-        print(f"   ✗ Error: {e}")
+        print(f"   ERROR: Error: {e}")
 
     return query_runs.items[0] if query_runs.items else None
 
 
-def test_create_query_runs(client, organization_name):
-    """Test creating different types of query runs."""
+def test_create_query_run(client, workspace_id):
+    """Test creating a query run."""
     print("\n=== Testing Query Run Creation ===")
 
-    created_query_runs = []
-
-    # 1. Create a filter query run
-    print("\n1. Creating Filter Query Run:")
+    # Create a query run
+    print("\n1. Creating Query Run:")
     try:
         options = QueryRunCreateOptions(
-            query="SELECT id, status, created_at FROM runs WHERE status = 'completed' ORDER BY created_at DESC",
-            query_type=QueryRunType.FILTER,
-            organization_name=organization_name,
-            timeout_seconds=300,
-            max_results=100,
+            source=QueryRunSource.API,
+            workspace_id=workspace_id,
         )
-        query_run = client.query_runs.create(organization_name, options)
-        created_query_runs.append(query_run)
-        print(f"   ✓ Created filter query run: {query_run.id}")
-        print(f"   ✓ Status: {query_run.status}")
-        print(f"   ✓ Query: {query_run.query}")
+        query_run = client.query_runs.create(options)
+        print(f"   SUCCESS: Created query run: {query_run.id}")
+        print(f"   SUCCESS: Status: {query_run.status}")
+        print(f"   SUCCESS: Source: {query_run.source}")
+        print(f"   SUCCESS: Created at: {query_run.created_at}")
+        return query_run
     except Exception as e:
-        print(f"   ✗ Error: {e}")
-
-    # 2. Create a search query run
-    print("\n2. Creating Search Query Run:")
-    try:
-        options = QueryRunCreateOptions(
-            query="SEARCH workspaces WHERE name CONTAINS 'production'",
-            query_type=QueryRunType.SEARCH,
-            organization_name=organization_name,
-            timeout_seconds=180,
-            max_results=50,
-        )
-        query_run = client.query_runs.create(organization_name, options)
-        created_query_runs.append(query_run)
-        print(f"   ✓ Created search query run: {query_run.id}")
-        print(f"   ✓ Status: {query_run.status}")
-        print(f"   ✓ Query type: {query_run.query_type}")
-    except Exception as e:
-        print(f"   ✗ Error: {e}")
-
-    # 3. Create an analytics query run
-    print("\n3. Creating Analytics Query Run:")
-    try:
-        options = QueryRunCreateOptions(
-            query="ANALYZE run_durations GROUP BY workspace_id ORDER BY avg_duration DESC",
-            query_type=QueryRunType.ANALYTICS,
-            organization_name=organization_name,
-            timeout_seconds=600,
-            max_results=200,
-            filters={"time_range": "last_30_days", "include_failed": False},
-        )
-        query_run = client.query_runs.create(organization_name, options)
-        created_query_runs.append(query_run)
-        print(f"   ✓ Created analytics query run: {query_run.id}")
-        print(f"   ✓ Status: {query_run.status}")
-        print(f"   ✓ Timeout: {query_run.timeout_seconds}s")
-        print(f"   ✓ Max results: {query_run.max_results}")
-    except Exception as e:
-        print(f"   ✗ Error: {e}")
-
-    return created_query_runs
+        print(f"   ERROR: Error: {e}")
+        return None
 
 
 def test_read_query_run(client, query_run_id):
@@ -160,32 +113,31 @@ def test_read_query_run(client, query_run_id):
     print("\n1. Reading Query Run Details:")
     try:
         query_run = client.query_runs.read(query_run_id)
-        print(f"   ✓ Query Run ID: {query_run.id}")
-        print(f"   ✓ Status: {query_run.status}")
-        print(f"   ✓ Query Type: {query_run.query_type}")
-        print(f"   ✓ Created: {query_run.created_at}")
-        print(f"   ✓ Updated: {query_run.updated_at}")
-        if query_run.results_count:
-            print(f"   ✓ Results Count: {query_run.results_count}")
-        if query_run.error_message:
-            print(f"   ✗ Error: {query_run.error_message}")
+        print(f"   SUCCESS: Query Run ID: {query_run.id}")
+        print(f"   SUCCESS: Status: {query_run.status}")
+        print(f"   SUCCESS: Source: {query_run.source}")
+        print(f"   SUCCESS: Created: {query_run.created_at}")
+        print(f"   SUCCESS: Updated: {query_run.updated_at}")
+        if query_run.actions:
+            print(f"   SUCCESS: Is Cancelable: {query_run.actions.is_cancelable}")
+            print(f"   SUCCESS: Is Force Cancelable: {query_run.actions.is_force_cancelable}")
+        if query_run.log_read_url:
+            print(f"   SUCCESS: Log URL available")
     except Exception as e:
-        print(f"   ✗ Error: {e}")
+        print(f"   ERROR: Error: {e}")
         return None
 
     # 2. Read with options
     print("\n2. Reading Query Run with Options:")
     try:
-        options = QueryRunReadOptions(include_results=True, include_logs=True)
+        options = QueryRunReadOptions(
+            include=[QueryRunIncludeOpt.CREATED_BY, QueryRunIncludeOpt.CONFIGURATION_VERSION]
+        )
         query_run = client.query_runs.read_with_options(query_run_id, options)
-        print("   ✓ Read query run with additional data")
-        print(f"   ✓ Status: {query_run.status}")
-        if query_run.logs_url:
-            print(f"   ✓ Logs URL available: {query_run.logs_url[:50]}...")
-        if query_run.results_url:
-            print(f"   ✓ Results URL available: {query_run.results_url[:50]}...")
+        print("   SUCCESS: Read query run with additional data")
+        print(f"   SUCCESS: Status: {query_run.status}")
     except Exception as e:
-        print(f"   ✗ Error: {e}")
+        print(f"   ERROR: Error: {e}")
 
     return query_run
 
@@ -195,41 +147,25 @@ def test_query_run_logs(client, query_run_id):
     print(f"\n=== Testing Query Run Logs for {query_run_id} ===")
 
     try:
-        logs = client.query_runs.logs(query_run_id)
-        print(f"   ✓ Retrieved logs for query run: {logs.query_run_id}")
-        print(f"   ✓ Log level: {logs.log_level}")
-        if logs.timestamp:
-            print(f"   ✓ Log timestamp: {logs.timestamp}")
+        logs_stream = client.query_runs.logs(query_run_id)
+        log_content = logs_stream.read()
+        
+        if isinstance(log_content, bytes):
+            log_text = log_content.decode('utf-8')
+        else:
+            log_text = log_content
+            
+        print(f"   SUCCESS: Retrieved logs for query run")
+        print(f"   SUCCESS: Log size: {len(log_text)} characters")
 
         # Show first few lines of logs
-        log_lines = logs.logs.split("\n")[:5]
-        print("   ✓ Log preview:")
+        log_lines = log_text.split("\n")[:5]
+        print("   SUCCESS: Log preview:")
         for line in log_lines:
             if line.strip():
                 print(f"     {line}")
     except Exception as e:
-        print(f"   ✗ Error retrieving logs: {e}")
-
-
-def test_query_run_results(client, query_run_id):
-    """Test retrieving query run results."""
-    print(f"\n=== Testing Query Run Results for {query_run_id} ===")
-
-    try:
-        results = client.query_runs.results(query_run_id)
-        print(f"   ✓ Retrieved results for query run: {results.query_run_id}")
-        print(f"   ✓ Total results: {results.total_count}")
-        print(f"   ✓ Truncated: {results.truncated}")
-
-        # Show first few results
-        if results.results:
-            print("   ✓ Sample results:")
-            for i, result in enumerate(results.results[:3]):
-                print(f"     {i + 1}. {result}")
-        else:
-            print("   ℹ No results available")
-    except Exception as e:
-        print(f"   ✗ Error retrieving results: {e}")
+        print(f"   ERROR: Error retrieving logs: {e}")
 
 
 def test_query_run_cancellation(client, query_run_id):
@@ -239,53 +175,33 @@ def test_query_run_cancellation(client, query_run_id):
     # First check if the query run is in a cancelable state
     try:
         query_run = client.query_runs.read(query_run_id)
-        if query_run.status not in [QueryRunStatus.PENDING, QueryRunStatus.RUNNING]:
+        if query_run.status not in [QueryRunStatus.PENDING, QueryRunStatus.QUEUED, QueryRunStatus.RUNNING]:
             print(
-                f"   ℹ Query run is {query_run.status}, creating new one for cancellation test"
+                f"   INFO: Query run is {query_run.status}, not in a cancelable state"
             )
-
-            # Create a new query run for cancellation test
-            options = QueryRunCreateOptions(
-                query="SELECT * FROM runs LIMIT 10000",  # Large query to ensure it runs long enough
-                query_type=QueryRunType.FILTER,
-                organization_name=query_run.organization_name,
-                timeout_seconds=300,
-            )
-            query_run = client.query_runs.create(query_run.organization_name, options)
-            query_run_id = query_run.id
-            print(f"   ✓ Created new query run for cancellation: {query_run_id}")
+            return
+            
+        if not query_run.actions or not query_run.actions.is_cancelable:
+            print(f"   INFO: Query run is not cancelable")
+            return
     except Exception as e:
-        print(f"   ✗ Error checking query run status: {e}")
+        print(f"   ERROR: Error checking query run status: {e}")
         return
 
-    # 1. Test regular cancel
+    # Test regular cancel
     print("\n1. Testing Regular Cancellation:")
     try:
-        cancel_options = QueryRunCancelOptions(
-            reason="User requested cancellation for testing"
-        )
-        canceled_query_run = client.query_runs.cancel(query_run_id, cancel_options)
-        print(f"   ✓ Canceled query run: {canceled_query_run.id}")
-        print(f"   ✓ New status: {canceled_query_run.status}")
+        client.query_runs.cancel(query_run_id)
+        print(f"   SUCCESS: Canceled query run: {query_run_id}")
+        
+        # Read to verify
+        query_run = client.query_runs.read(query_run_id)
+        print(f"   SUCCESS: New status: {query_run.status}")
     except Exception as e:
-        print(f"   ✗ Error canceling query run: {e}")
-
-        # If regular cancel fails, try force cancel
-        print("\n2. Testing Force Cancellation:")
-        try:
-            force_cancel_options = QueryRunForceCancelOptions(
-                reason="Force cancel after regular cancel failed"
-            )
-            force_canceled_query_run = client.query_runs.force_cancel(
-                query_run_id, force_cancel_options
-            )
-            print(f"   ✓ Force canceled query run: {force_canceled_query_run.id}")
-            print(f"   ✓ New status: {force_canceled_query_run.status}")
-        except Exception as e:
-            print(f"   ✗ Error force canceling query run: {e}")
+        print(f"   ERROR: Error canceling query run: {e}")
 
 
-def test_query_run_workflow(client, organization_name):
+def test_query_run_workflow(client, workspace_id):
     """Test a complete query run workflow."""
     print("\n=== Testing Complete Query Run Workflow ===")
 
@@ -293,17 +209,14 @@ def test_query_run_workflow(client, organization_name):
     print("\n1. Creating Query Run:")
     try:
         options = QueryRunCreateOptions(
-            query="SELECT id, name, status FROM workspaces ORDER BY created_at DESC LIMIT 10",
-            query_type=QueryRunType.FILTER,
-            organization_name=organization_name,
-            timeout_seconds=120,
-            max_results=50,
+            source=QueryRunSource.API,
+            workspace_id=workspace_id,
         )
-        query_run = client.query_runs.create(organization_name, options)
-        print(f"   ✓ Created: {query_run.id}")
+        query_run = client.query_runs.create(options)
+        print(f"   SUCCESS: Created: {query_run.id}")
         query_run_id = query_run.id
     except Exception as e:
-        print(f"   ✗ Error creating query run: {e}")
+        print(f"   ERROR: Error creating query run: {e}")
         return
 
     # 2. Monitor execution
@@ -317,7 +230,7 @@ def test_query_run_workflow(client, organization_name):
             print(f"   Attempt {attempt + 1}: Status = {query_run.status}")
 
             if query_run.status in [
-                QueryRunStatus.COMPLETED,
+                QueryRunStatus.FINISHED,
                 QueryRunStatus.ERRORED,
                 QueryRunStatus.CANCELED,
             ]:
@@ -326,27 +239,24 @@ def test_query_run_workflow(client, organization_name):
             time.sleep(2)  # Wait 2 seconds before checking again
             attempt += 1
         except Exception as e:
-            print(f"   ✗ Error monitoring query run: {e}")
+            print(f"   ERROR: Error monitoring query run: {e}")
             break
 
-    # 3. Get final results
-    print("\n3. Getting Final Results:")
+    # 3. Get final logs if finished
+    print("\n3. Getting Final Status:")
     try:
-        if query_run.status == QueryRunStatus.COMPLETED:
-            results = client.query_runs.results(query_run_id)
-            print("   ✓ Query completed successfully")
-            print(f"   ✓ Total results: {results.total_count}")
-            print(f"   ✓ Truncated: {results.truncated}")
-
+        if query_run.status == QueryRunStatus.FINISHED:
+            print("   SUCCESS: Query completed successfully")
+            
             # Get logs
-            logs = client.query_runs.logs(query_run_id)
-            print(f"   ✓ Retrieved execution logs ({len(logs.logs)} characters)")
+            if query_run.log_read_url:
+                logs_stream = client.query_runs.logs(query_run_id)
+                log_content = logs_stream.read()
+                print(f"   SUCCESS: Retrieved execution logs ({len(log_content)} bytes)")
         else:
-            print(f"   ✗ Query run finished with status: {query_run.status}")
-            if query_run.error_message:
-                print(f"   ✗ Error message: {query_run.error_message}")
+            print(f"   ERROR: Query run finished with status: {query_run.status}")
     except Exception as e:
-        print(f"   ✗ Error getting final results: {e}")
+        print(f"   ERROR: Error getting final results: {e}")
 
     return query_run_id
 
@@ -355,21 +265,22 @@ def main():
     """Main function to demonstrate query run operations."""
     # Get configuration from environment
     token = os.environ.get("TFE_TOKEN")
-    org = os.environ.get("TFE_ORG")
+    workspace_id = os.environ.get("TFE_WORKSPACE_ID")
     address = os.environ.get("TFE_ADDRESS", "https://app.terraform.io")
 
     if not token:
         print("Error: TFE_TOKEN environment variable is required")
         return 1
 
-    if not org:
-        print("Error: TFE_ORG environment variable is required")
+    if not workspace_id:
+        print("Error: TFE_WORKSPACE_ID environment variable is required")
+        print("  Set it to the workspace ID where you want to run queries")
         return 1
 
     # Initialize client
     print("=== Terraform Enterprise Query Run SDK Example ===")
     print(f"Address: {address}")
-    print(f"Organization: {org}")
+    print(f"Workspace ID: {workspace_id}")
     print(f"Timestamp: {datetime.now()}")
 
     config = TFEConfig(address=address, token=token)
@@ -377,26 +288,25 @@ def main():
 
     try:
         # 1. List existing query runs
-        existing_query_run = test_list_query_runs(client, org)
+        existing_query_run = test_list_query_runs(client, workspace_id)
 
-        # 2. Create new query runs
-        created_query_runs = test_create_query_runs(client, org)
+        # 2. Create a new query run
+        created_query_run = test_create_query_run(client, workspace_id)
 
         # 3. Test read operations
         if existing_query_run:
             test_read_query_run(client, existing_query_run.id)
 
-            # Only test logs and results if query run is completed
-            if existing_query_run.status == QueryRunStatus.COMPLETED:
+            # Only test logs if query run is finished
+            if existing_query_run.status == QueryRunStatus.FINISHED:
                 test_query_run_logs(client, existing_query_run.id)
-                test_query_run_results(client, existing_query_run.id)
 
-        # 4. Test cancellation (with a new query run if needed)
-        if created_query_runs:
-            test_query_run_cancellation(client, created_query_runs[0].id)
+        # 4. Test cancellation (if query run is cancelable)
+        if created_query_run:
+            test_query_run_cancellation(client, created_query_run.id)
 
         # 5. Test complete workflow
-        test_query_run_workflow(client, org)
+        test_query_run_workflow(client, workspace_id)
 
         print("\n" + "=" * 80)
         print("Query Run operations completed successfully!")
@@ -404,6 +314,8 @@ def main():
 
     except Exception as e:
         print(f"\nUnexpected error: {e}")
+        import traceback
+        traceback.print_exc()
         return 1
 
     return 0

--- a/examples/query_run.py
+++ b/examples/query_run.py
@@ -6,12 +6,12 @@ This file provides individual test functions for each query run operation.
 You can run specific functions to test individual parts of the API.
 
 Functions available:
-- test_list() - List query runs in a workspace
-- test_create() - Create a new query run
-- test_read() - Read a specific query run
-- test_logs() - Retrieve logs for a query run
-- test_cancel() - Cancel a query run
-- test_force_cancel() - Force cancel a query run
+- run_list() - List query runs in a workspace
+- run_create() - Create a new query run
+- run_read() - Read a specific query run
+- run_logs() - Retrieve logs for a query run
+- run_cancel() - Cancel a query run
+- run_force_cancel() - Force cancel a query run
 
 Usage:
     python query_run.py
@@ -42,7 +42,7 @@ def get_client_and_workspace():
     return client, workspace
 
 
-def test_list():
+def run_list():
     """Test 1: List query runs in a workspace."""
     print("=== Test 1: List Query Runs ===")
 
@@ -71,7 +71,7 @@ def test_list():
         return []
 
 
-def test_create():
+def run_create():
     """Test 2: Create a new query run."""
     print("\n=== Test 2: Create Query Run ===")
 
@@ -107,7 +107,7 @@ def test_create():
         return None
 
 
-def test_read(query_run_id=None):
+def run_read(query_run_id=None):
     """Test 3: Read a specific query run."""
     print("\n=== Test 3: Read Query Run ===")
 
@@ -148,7 +148,7 @@ def test_read(query_run_id=None):
         return None
 
 
-def test_logs(query_run_id=None):
+def run_logs(query_run_id=None):
     """Test 4: Retrieve logs for a query run."""
     print("\n=== Test 4: Get Query Run Logs ===")
 
@@ -184,7 +184,7 @@ def test_logs(query_run_id=None):
         return None
 
 
-def test_cancel(query_run_id=None):
+def run_cancel(query_run_id=None):
     """Test 5: Cancel a query run."""
     print("\n=== Test 5: Cancel Query Run ===")
 
@@ -194,7 +194,7 @@ def test_cancel(query_run_id=None):
         # If no query_run_id provided, create a new one
         if not query_run_id:
             print("Creating a new query run to cancel...")
-            new_run = test_create()
+            new_run = run_create()
             if not new_run:
                 print("ERROR: Could not create query run to cancel")
                 return False
@@ -218,7 +218,7 @@ def test_cancel(query_run_id=None):
         return False
 
 
-def test_force_cancel(query_run_id=None):
+def run_force_cancel(query_run_id=None):
     """Test 6: Force cancel a query run."""
     print("\n=== Test 6: Force Cancel Query Run ===")
 
@@ -228,7 +228,7 @@ def test_force_cancel(query_run_id=None):
         # If no query_run_id provided, create a new one
         if not query_run_id:
             print("Creating a new query run to force cancel...")
-            new_run = test_create()
+            new_run = run_create()
             if not new_run:
                 print("ERROR: Could not create query run to force cancel")
                 return False
@@ -264,26 +264,26 @@ def main():
     print("=" * 80)
 
     # Test 1: List query runs
-    query_runs = test_list()
+    query_runs = run_list()
 
     # Test 2: Create a query run
-    new_query_run = test_create()
+    new_query_run = run_create()
 
     # Test 3: Read a query run
     if query_runs:
-        test_read(query_runs[0].id)
+        run_read(query_runs[0].id)
     elif new_query_run:
-        test_read(new_query_run.id)
+        run_read(new_query_run.id)
 
     # Test 4: Get logs (use first query run from list)
     if query_runs:
-        test_logs(query_runs[0].id)
+        run_logs(query_runs[0].id)
 
     # Test 5: Cancel a query run (creates new one)
-    test_cancel()
+    run_cancel()
 
     # Test 6: Force cancel a query run (creates new one)
-    test_force_cancel()
+    run_force_cancel()
 
 
 if __name__ == "__main__":

--- a/examples/query_run.py
+++ b/examples/query_run.py
@@ -15,7 +15,7 @@ Functions available:
 
 Usage:
     python query_run.py
-    
+
 Note: Query Runs require Terraform ~>1.14 which includes the 'terraform query' command.
       These tests may fail with error status since the feature is not fully available yet.
 """
@@ -36,7 +36,7 @@ def get_client_and_workspace():
     client = TFEClient(TFEConfig.from_env())
     organization = os.getenv("TFE_ORG", "aayush-test")
     workspace_name = "query-test"  # Default workspace for testing
-    
+
     # Get workspace
     workspace = client.workspaces.read(workspace_name, organization=organization)
     return client, workspace
@@ -45,27 +45,27 @@ def get_client_and_workspace():
 def test_list():
     """Test 1: List query runs in a workspace."""
     print("=== Test 1: List Query Runs ===")
-    
+
     client, workspace = get_client_and_workspace()
-    
+
     try:
         # Simple list
         query_runs = list(client.query_runs.list(workspace.id))
         print(f"Found {len(query_runs)} query runs in workspace '{workspace.name}'")
-        
+
         for i, qr in enumerate(query_runs[:5], 1):
             print(f"  {i}. {qr.id}")
             print(f"     Status: {qr.status}")
             print(f"     Created: {qr.created_at}")
             print()
-        
+
         # List with options
         options = QueryRunListOptions(page_size=5)
         limited_runs = list(client.query_runs.list(workspace.id, options))
         print(f"Retrieved {len(limited_runs)} query runs (page_size=5)")
-        
+
         return query_runs
-        
+
     except Exception as e:
         print(f"Error: {e}")
         return []
@@ -74,34 +74,34 @@ def test_list():
 def test_create():
     """Test 2: Create a new query run."""
     print("\n=== Test 2: Create Query Run ===")
-    
+
     client, workspace = get_client_and_workspace()
-    
+
     try:
         # Get the latest configuration version
         config_versions = list(client.configuration_versions.list(workspace.id))
         if not config_versions:
             print("ERROR: No configuration versions found in workspace")
             return None
-        
+
         config_version = config_versions[0]
         print(f"Using configuration version: {config_version.id}")
-        
+
         # Create query run
         options = QueryRunCreateOptions(
             source=QueryRunSource.API,
             workspace_id=workspace.id,
             configuration_version_id=config_version.id,
         )
-        
+
         query_run = client.query_runs.create(options)
         print(f"Created query run: {query_run.id}")
         print(f"  Status: {query_run.status}")
         print(f"  Source: {query_run.source}")
         print(f"  Created: {query_run.created_at}")
-        
+
         return query_run
-        
+
     except Exception as e:
         print(f"Error: {e}")
         return None
@@ -110,9 +110,9 @@ def test_create():
 def test_read(query_run_id=None):
     """Test 3: Read a specific query run."""
     print("\n=== Test 3: Read Query Run ===")
-    
+
     client, workspace = get_client_and_workspace()
-    
+
     try:
         # If no query_run_id provided, get the first one from the list
         if not query_run_id:
@@ -122,16 +122,16 @@ def test_read(query_run_id=None):
                 return None
             query_run_id = query_runs[0].id
             print(f"Using first query run from list: {query_run_id}")
-        
+
         # Read the query run
         query_run = client.query_runs.read(query_run_id)
         print(f"Read query run: {query_run.id}")
         print(f"  Status: {query_run.status}")
         print(f"  Source: {query_run.source}")
         print(f"  Created: {query_run.created_at}")
-        
+
         if query_run.status_timestamps:
-            print(f"  Status Timestamps:")
+            print("  Status Timestamps:")
             if query_run.status_timestamps.queued_at:
                 print(f"    Queued: {query_run.status_timestamps.queued_at}")
             if query_run.status_timestamps.running_at:
@@ -140,9 +140,9 @@ def test_read(query_run_id=None):
                 print(f"    Finished: {query_run.status_timestamps.finished_at}")
             if query_run.status_timestamps.errored_at:
                 print(f"    Errored: {query_run.status_timestamps.errored_at}")
-        
+
         return query_run
-        
+
     except Exception as e:
         print(f"Error: {e}")
         return None
@@ -151,9 +151,9 @@ def test_read(query_run_id=None):
 def test_logs(query_run_id=None):
     """Test 4: Retrieve logs for a query run."""
     print("\n=== Test 4: Get Query Run Logs ===")
-    
+
     client, workspace = get_client_and_workspace()
-    
+
     try:
         # If no query_run_id provided, get the first one from the list
         if not query_run_id:
@@ -163,33 +163,33 @@ def test_logs(query_run_id=None):
                 return None
             query_run_id = query_runs[0].id
             print(f"Using first query run from list: {query_run_id}")
-        
+
         # Get logs
         logs = client.query_runs.logs(query_run_id)
         log_content = logs.read().decode("utf-8")
-        
+
         print(f"Retrieved logs for query run: {query_run_id}")
         print(f"  Log size: {len(log_content)} bytes")
-        print(f"\n--- Log Preview (first 500 chars) ---")
+        print("\n--- Log Preview (first 500 chars) ---")
         print(log_content[:500])
         if len(log_content) > 500:
             print(f"\n... ({len(log_content) - 500} more characters)")
         print("--- End of Log Preview ---")
-        
+
         return log_content
-        
+
     except Exception as e:
         print(f"Error: {e}")
-        print(f"  Note: Logs may not be available if the query run hasn't started yet")
+        print("  Note: Logs may not be available if the query run hasn't started yet")
         return None
 
 
 def test_cancel(query_run_id=None):
     """Test 5: Cancel a query run."""
     print("\n=== Test 5: Cancel Query Run ===")
-    
+
     client, workspace = get_client_and_workspace()
-    
+
     try:
         # If no query_run_id provided, create a new one
         if not query_run_id:
@@ -200,30 +200,30 @@ def test_cancel(query_run_id=None):
                 return False
             query_run_id = new_run.id
             time.sleep(1)  # Give it a moment to start
-        
+
         # Cancel the query run
         client.query_runs.cancel(query_run_id)
         print(f"Cancel requested for query run: {query_run_id}")
-        
+
         # Verify cancellation
         time.sleep(2)
         query_run = client.query_runs.read(query_run_id)
         print(f"  Status after cancel: {query_run.status}")
-        
+
         return True
-        
+
     except Exception as e:
         print(f"Error: {e}")
-        print(f"  Note: Query run may not be in a cancelable state")
+        print("  Note: Query run may not be in a cancelable state")
         return False
 
 
 def test_force_cancel(query_run_id=None):
     """Test 6: Force cancel a query run."""
     print("\n=== Test 6: Force Cancel Query Run ===")
-    
+
     client, workspace = get_client_and_workspace()
-    
+
     try:
         # If no query_run_id provided, create a new one
         if not query_run_id:
@@ -234,21 +234,21 @@ def test_force_cancel(query_run_id=None):
                 return False
             query_run_id = new_run.id
             time.sleep(1)  # Give it a moment to start
-        
+
         # Force cancel the query run
         client.query_runs.force_cancel(query_run_id)
         print(f"Force cancel requested for query run: {query_run_id}")
-        
+
         # Verify force cancellation
         time.sleep(2)
         query_run = client.query_runs.read(query_run_id)
         print(f"  Status after force cancel: {query_run.status}")
-        
+
         return True
-        
+
     except Exception as e:
         print(f"Error: {e}")
-        print(f"  Note: Query run may not be in a force-cancelable state")
+        print("  Note: Query run may not be in a force-cancelable state")
         return False
 
 
@@ -262,26 +262,26 @@ def main():
     print("NOTE: Query Runs require Terraform 1.10+ with 'terraform query' command.")
     print("      Most query runs will error since this feature is not yet available.")
     print("=" * 80)
-    
+
     # Test 1: List query runs
     query_runs = test_list()
-    
+
     # Test 2: Create a query run
     new_query_run = test_create()
-    
+
     # Test 3: Read a query run
     if query_runs:
         test_read(query_runs[0].id)
     elif new_query_run:
         test_read(new_query_run.id)
-    
+
     # Test 4: Get logs (use first query run from list)
     if query_runs:
         test_logs(query_runs[0].id)
-    
+
     # Test 5: Cancel a query run (creates new one)
     test_cancel()
-    
+
     # Test 6: Force cancel a query run (creates new one)
     test_force_cancel()
 

--- a/src/pytfe/models/__init__.py
+++ b/src/pytfe/models/__init__.py
@@ -434,12 +434,10 @@ __all__ = [
     "RegistryProviderReadOptions",
     # Query runs
     "QueryRun",
-    "QueryRunActions",
     "QueryRunCancelOptions",
     "QueryRunCreateOptions",
     "QueryRunForceCancelOptions",
     "QueryRunIncludeOpt",
-    "QueryRunList",
     "QueryRunListOptions",
     "QueryRunReadOptions",
     "QueryRunSource",

--- a/src/pytfe/models/__init__.py
+++ b/src/pytfe/models/__init__.py
@@ -434,10 +434,12 @@ __all__ = [
     "RegistryProviderReadOptions",
     # Query runs
     "QueryRun",
+    "QueryRunActions",
     "QueryRunCancelOptions",
     "QueryRunCreateOptions",
     "QueryRunForceCancelOptions",
     "QueryRunIncludeOpt",
+    "QueryRunList",
     "QueryRunListOptions",
     "QueryRunReadOptions",
     "QueryRunSource",

--- a/src/pytfe/models/__init__.py
+++ b/src/pytfe/models/__init__.py
@@ -149,11 +149,8 @@ from .project import (
 from .query_run import (
     QueryRun,
     QueryRunActions,
-    QueryRunCancelOptions,
     QueryRunCreateOptions,
-    QueryRunForceCancelOptions,
     QueryRunIncludeOpt,
-    QueryRunList,
     QueryRunListOptions,
     QueryRunReadOptions,
     QueryRunSource,
@@ -435,11 +432,8 @@ __all__ = [
     # Query runs
     "QueryRun",
     "QueryRunActions",
-    "QueryRunCancelOptions",
     "QueryRunCreateOptions",
-    "QueryRunForceCancelOptions",
     "QueryRunIncludeOpt",
-    "QueryRunList",
     "QueryRunListOptions",
     "QueryRunReadOptions",
     "QueryRunSource",

--- a/src/pytfe/models/__init__.py
+++ b/src/pytfe/models/__init__.py
@@ -148,16 +148,18 @@ from .project import (
 # ── Query Runs ────────────────────────────────────────────────────────────────
 from .query_run import (
     QueryRun,
+    QueryRunActions,
     QueryRunCancelOptions,
     QueryRunCreateOptions,
     QueryRunForceCancelOptions,
+    QueryRunIncludeOpt,
     QueryRunList,
     QueryRunListOptions,
-    QueryRunLogs,
     QueryRunReadOptions,
-    QueryRunResults,
+    QueryRunSource,
     QueryRunStatus,
-    QueryRunType,
+    QueryRunStatusTimestamps,
+    QueryRunVariable,
 )
 
 # ── Registry Modules / Providers ──────────────────────────────────────────────
@@ -432,16 +434,18 @@ __all__ = [
     "RegistryProviderReadOptions",
     # Query runs
     "QueryRun",
+    "QueryRunActions",
     "QueryRunCancelOptions",
     "QueryRunCreateOptions",
     "QueryRunForceCancelOptions",
+    "QueryRunIncludeOpt",
     "QueryRunList",
     "QueryRunListOptions",
-    "QueryRunLogs",
     "QueryRunReadOptions",
-    "QueryRunResults",
+    "QueryRunSource",
     "QueryRunStatus",
-    "QueryRunType",
+    "QueryRunStatusTimestamps",
+    "QueryRunVariable",
     # Core (from old types.py, now split)
     "Entitlements",
     "ExecutionMode",

--- a/src/pytfe/models/query_run.py
+++ b/src/pytfe/models/query_run.py
@@ -11,18 +11,64 @@ class QueryRunStatus(str, Enum):
     """QueryRunStatus represents the status of a query run operation."""
 
     PENDING = "pending"
+    QUEUED = "queued"
     RUNNING = "running"
-    COMPLETED = "completed"
+    FINISHED = "finished"
     ERRORED = "errored"
     CANCELED = "canceled"
 
 
-class QueryRunType(str, Enum):
-    """QueryRunType represents different types of query runs."""
+class QueryRunSource(str, Enum):
+    """QueryRunSource represents the source of a query run."""
 
-    FILTER = "filter"
-    SEARCH = "search"
-    ANALYTICS = "analytics"
+    API = "tfe-api"
+
+
+class QueryRunActions(BaseModel):
+    """Actions available on a query run."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    is_cancelable: bool = Field(
+        ..., alias="is-cancelable", description="Whether the query run can be canceled"
+    )
+    is_force_cancelable: bool = Field(
+        ...,
+        alias="is-force-cancelable",
+        description="Whether the query run can be force canceled",
+    )
+
+
+class QueryRunStatusTimestamps(BaseModel):
+    """Timestamps for each status of a query run."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    pending_at: datetime | None = Field(
+        None, alias="pending-at", description="When the query run was created"
+    )
+    queued_at: datetime | None = Field(
+        None, alias="queued-at", description="When the query run was queued"
+    )
+    running_at: datetime | None = Field(
+        None, alias="running-at", description="When the query run started running"
+    )
+    finished_at: datetime | None = Field(
+        None, alias="finished-at", description="When the query run finished successfully"
+    )
+    errored_at: datetime | None = Field(
+        None, alias="errored-at", description="When the query run encountered an error"
+    )
+    canceled_at: datetime | None = Field(
+        None, alias="canceled-at", description="When the query run was canceled"
+    )
+
+
+class QueryRunVariable(BaseModel):
+    """A variable for a query run."""
+
+    key: str = Field(..., description="Variable key")
+    value: str = Field(..., description="Variable value")
 
 
 class QueryRun(BaseModel):
@@ -31,16 +77,12 @@ class QueryRun(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     id: str = Field(..., description="The unique identifier for this query run")
-    type: str = Field(default="query-runs", description="The type of this resource")
-    query: str = Field(..., description="The query string used for this run")
-    query_type: QueryRunType = Field(
-        ..., alias="query-type", description="The type of query being executed"
+    type: str = Field(default="queries", description="The type of this resource")
+    actions: QueryRunActions | None = Field(
+        None, description="Actions available on this query run"
     )
-    status: QueryRunStatus = Field(
-        ..., description="The current status of the query run"
-    )
-    results_count: int | None = Field(
-        None, alias="results-count", description="The number of results returned"
+    canceled_at: datetime | None = Field(
+        None, alias="canceled-at", description="When the query run was canceled"
     )
     created_at: datetime = Field(
         ..., alias="created-at", description="The time this query run was created"
@@ -48,34 +90,35 @@ class QueryRun(BaseModel):
     updated_at: datetime = Field(
         ..., alias="updated-at", description="The time this query run was last updated"
     )
-    started_at: datetime | None = Field(
-        None, alias="started-at", description="The time this query run was started"
+    source: QueryRunSource | str = Field(
+        ..., description="The source of the query run"
     )
-    finished_at: datetime | None = Field(
-        None, alias="finished-at", description="The time this query run was finished"
+    status: QueryRunStatus = Field(
+        ..., description="The current status of the query run"
     )
-    error_message: str | None = Field(
-        None, alias="error-message", description="Error message if the query run failed"
-    )
-    logs_url: str | None = Field(
-        None, alias="logs-url", description="URL to retrieve the query run logs"
-    )
-    results_url: str | None = Field(
-        None, alias="results-url", description="URL to retrieve the query run results"
-    )
-    workspace_id: str | None = Field(
+    status_timestamps: QueryRunStatusTimestamps | None = Field(
         None,
-        alias="workspace-id",
-        description="The workspace ID if query is workspace-scoped",
+        alias="status-timestamps",
+        description="Timestamps for each status of the query run",
     )
-    organization_name: str | None = Field(
-        None, alias="organization-name", description="The organization name"
+    variables: list[QueryRunVariable] | None = Field(
+        None, description="Run-specific variable values"
     )
-    timeout_seconds: int | None = Field(
-        None, alias="timeout-seconds", description="Query timeout in seconds"
+    log_read_url: str | None = Field(
+        None, alias="log-read-url", description="URL to retrieve the query run logs"
     )
-    max_results: int | None = Field(
-        None, alias="max-results", description="Maximum number of results to return"
+    # Relationships
+    workspace_id: str | None = Field(
+        None, description="The workspace ID associated with this query run"
+    )
+    configuration_version_id: str | None = Field(
+        None, description="The configuration version ID used for this query run"
+    )
+    created_by_id: str | None = Field(
+        None, description="The user ID who created this query run"
+    )
+    canceled_by_id: str | None = Field(
+        None, description="The user ID who canceled this query run"
     )
 
 
@@ -84,34 +127,29 @@ class QueryRunCreateOptions(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    query: str = Field(..., description="The query string to execute")
-    query_type: QueryRunType = Field(
-        ..., alias="query-type", description="The type of query being executed"
+    source: QueryRunSource | str = Field(
+        ..., description="The source of the query run"
     )
-    workspace_id: str | None = Field(
+    variables: list[QueryRunVariable] | None = Field(
+        None, description="Run-specific variable values"
+    )
+    workspace_id: str = Field(
+        ..., alias="workspace-id", description="The workspace ID to run the query against"
+    )
+    configuration_version_id: str | None = Field(
         None,
-        alias="workspace-id",
-        description="The workspace ID if query is workspace-scoped",
+        alias="configuration-version-id",
+        description="The configuration version ID to use for the query",
     )
-    organization_name: str | None = Field(
-        None, alias="organization-name", description="The organization name"
-    )
-    timeout_seconds: int | None = Field(
-        None,
-        alias="timeout-seconds",
-        description="Query timeout in seconds",
-        gt=0,
-        le=3600,
-    )
-    max_results: int | None = Field(
-        None,
-        alias="max-results",
-        description="Maximum number of results to return",
-        gt=0,
-        le=10000,
-    )
-    filters: dict[str, Any] | None = Field(
-        None, description="Additional filters to apply to the query"
+
+
+class QueryRunIncludeOpt(str, Enum):
+    """Options for including related resources in query run requests."""
+
+    CREATED_BY = "created-by"
+    CONFIGURATION_VERSION = "configuration-version"
+    CONFIGURATION_VERSION_INGRESS_ATTRIBUTES = (
+        "configuration_version.ingress_attributes"
     )
 
 
@@ -126,19 +164,8 @@ class QueryRunListOptions(BaseModel):
     page_size: int | None = Field(
         None, alias="page[size]", description="Number of items per page", ge=1, le=100
     )
-    query_type: QueryRunType | None = Field(
-        None, alias="filter[query-type]", description="Filter by query type"
-    )
-    status: QueryRunStatus | None = Field(
-        None, alias="filter[status]", description="Filter by status"
-    )
-    workspace_id: str | None = Field(
-        None, alias="filter[workspace-id]", description="Filter by workspace ID"
-    )
-    organization_name: str | None = Field(
-        None,
-        alias="filter[organization-name]",
-        description="Filter by organization name",
+    include: list[QueryRunIncludeOpt] | None = Field(
+        None, description="List of related resources to include"
     )
 
 
@@ -147,11 +174,8 @@ class QueryRunReadOptions(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    include_results: bool | None = Field(
-        None, alias="include[results]", description="Include query results in response"
-    )
-    include_logs: bool | None = Field(
-        None, alias="include[logs]", description="Include query logs in response"
+    include: list[QueryRunIncludeOpt] | None = Field(
+        None, description="List of related resources to include"
     )
 
 
@@ -160,7 +184,9 @@ class QueryRunCancelOptions(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    reason: str | None = Field(None, description="Reason for canceling the query run")
+    comment: str | None = Field(
+        None, description="Optional comment about why the query run was canceled"
+    )
 
 
 class QueryRunForceCancelOptions(BaseModel):
@@ -168,8 +194,8 @@ class QueryRunForceCancelOptions(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    reason: str | None = Field(
-        None, description="Reason for force canceling the query run"
+    comment: str | None = Field(
+        None, description="Optional comment about why the query run was force canceled"
     )
 
 
@@ -186,29 +212,3 @@ class QueryRunList(BaseModel):
     prev_page: str | None = Field(None, description="URL of the previous page")
     next_page: str | None = Field(None, description="URL of the next page")
     total_count: int | None = Field(None, description="Total number of items")
-
-
-class QueryRunResults(BaseModel):
-    """Represents the results of a query run."""
-
-    model_config = ConfigDict(populate_by_name=True)
-
-    query_run_id: str = Field(..., description="The ID of the query run")
-    results: list[dict[str, Any]] = Field(
-        default_factory=list, description="The query results"
-    )
-    total_count: int = Field(..., description="Total number of results")
-    truncated: bool = Field(
-        False, description="Whether the results were truncated due to limits"
-    )
-
-
-class QueryRunLogs(BaseModel):
-    """Represents the logs of a query run."""
-
-    model_config = ConfigDict(populate_by_name=True)
-
-    query_run_id: str = Field(..., description="The ID of the query run")
-    logs: str = Field(..., description="The query run logs")
-    log_level: str | None = Field(None, description="The log level")
-    timestamp: datetime | None = Field(None, description="When the logs were generated")

--- a/src/pytfe/models/query_run.py
+++ b/src/pytfe/models/query_run.py
@@ -157,9 +157,6 @@ class QueryRunListOptions(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    page_number: int | None = Field(
-        None, alias="page[number]", description="Page number to retrieve", ge=1
-    )
     page_size: int | None = Field(
         None, alias="page[size]", description="Number of items per page", ge=1, le=100
     )
@@ -176,38 +173,3 @@ class QueryRunReadOptions(BaseModel):
     include: list[QueryRunIncludeOpt] | None = Field(
         None, description="List of related resources to include"
     )
-
-
-class QueryRunCancelOptions(BaseModel):
-    """Options for canceling a query run."""
-
-    model_config = ConfigDict(populate_by_name=True)
-
-    comment: str | None = Field(
-        None, description="Optional comment about why the query run was canceled"
-    )
-
-
-class QueryRunForceCancelOptions(BaseModel):
-    """Options for force canceling a query run."""
-
-    model_config = ConfigDict(populate_by_name=True)
-
-    comment: str | None = Field(
-        None, description="Optional comment about why the query run was force canceled"
-    )
-
-
-class QueryRunList(BaseModel):
-    """Represents a paginated list of query runs."""
-
-    model_config = ConfigDict(populate_by_name=True)
-
-    items: list[QueryRun] = Field(
-        default_factory=list, description="List of query runs"
-    )
-    current_page: int | None = Field(None, description="Current page number")
-    total_pages: int | None = Field(None, description="Total number of pages")
-    prev_page: int | str | None = Field(None, description="Previous page number or URL")
-    next_page: int | str | None = Field(None, description="Next page number or URL")
-    total_count: int | None = Field(None, description="Total number of items")

--- a/src/pytfe/models/query_run.py
+++ b/src/pytfe/models/query_run.py
@@ -87,8 +87,8 @@ class QueryRun(BaseModel):
     created_at: datetime = Field(
         ..., alias="created-at", description="The time this query run was created"
     )
-    updated_at: datetime = Field(
-        ..., alias="updated-at", description="The time this query run was last updated"
+    updated_at: datetime | None = Field(
+        None, alias="updated-at", description="The time this query run was last updated"
     )
     source: QueryRunSource | str = Field(
         ..., description="The source of the query run"
@@ -146,8 +146,8 @@ class QueryRunCreateOptions(BaseModel):
 class QueryRunIncludeOpt(str, Enum):
     """Options for including related resources in query run requests."""
 
-    CREATED_BY = "created-by"
-    CONFIGURATION_VERSION = "configuration-version"
+    CREATED_BY = "created_by"
+    CONFIGURATION_VERSION = "configuration_version"
     CONFIGURATION_VERSION_INGRESS_ATTRIBUTES = (
         "configuration_version.ingress_attributes"
     )
@@ -209,6 +209,6 @@ class QueryRunList(BaseModel):
     )
     current_page: int | None = Field(None, description="Current page number")
     total_pages: int | None = Field(None, description="Total number of pages")
-    prev_page: str | None = Field(None, description="URL of the previous page")
-    next_page: str | None = Field(None, description="URL of the next page")
+    prev_page: int | str | None = Field(None, description="Previous page number or URL")
+    next_page: int | str | None = Field(None, description="Next page number or URL")
     total_count: int | None = Field(None, description="Total number of items")

--- a/src/pytfe/models/query_run.py
+++ b/src/pytfe/models/query_run.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -54,7 +53,9 @@ class QueryRunStatusTimestamps(BaseModel):
         None, alias="running-at", description="When the query run started running"
     )
     finished_at: datetime | None = Field(
-        None, alias="finished-at", description="When the query run finished successfully"
+        None,
+        alias="finished-at",
+        description="When the query run finished successfully",
     )
     errored_at: datetime | None = Field(
         None, alias="errored-at", description="When the query run encountered an error"
@@ -90,9 +91,7 @@ class QueryRun(BaseModel):
     updated_at: datetime | None = Field(
         None, alias="updated-at", description="The time this query run was last updated"
     )
-    source: QueryRunSource | str = Field(
-        ..., description="The source of the query run"
-    )
+    source: QueryRunSource | str = Field(..., description="The source of the query run")
     status: QueryRunStatus = Field(
         ..., description="The current status of the query run"
     )
@@ -127,14 +126,14 @@ class QueryRunCreateOptions(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    source: QueryRunSource | str = Field(
-        ..., description="The source of the query run"
-    )
+    source: QueryRunSource | str = Field(..., description="The source of the query run")
     variables: list[QueryRunVariable] | None = Field(
         None, description="Run-specific variable values"
     )
     workspace_id: str = Field(
-        ..., alias="workspace-id", description="The workspace ID to run the query against"
+        ...,
+        alias="workspace-id",
+        description="The workspace ID to run the query against",
     )
     configuration_version_id: str | None = Field(
         None,

--- a/src/pytfe/resources/query_run.py
+++ b/src/pytfe/resources/query_run.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import io
-from typing import Any, Iterator
+from collections.abc import Iterator
+from typing import Any
 
 from ..errors import (
     InvalidQueryRunIDError,
@@ -26,16 +27,16 @@ class QueryRuns(_Service):
         self, workspace_id: str, options: QueryRunListOptions | None = None
     ) -> Iterator[QueryRun]:
         """Iterate through all query runs for the given workspace.
-        
+
         This method automatically handles pagination and yields QueryRun objects one at a time.
-        
+
         Args:
             workspace_id: The ID of the workspace
             options: Optional list options (page_size, include, etc.)
-            
+
         Yields:
             QueryRun objects one at a time
-            
+
         Example:
             for query_run in client.query_runs.list(workspace_id):
                 print(f"Query Run: {query_run.id} - Status: {query_run.status}")
@@ -47,7 +48,7 @@ class QueryRuns(_Service):
         if options:
             params = options.model_dump(by_alias=True, exclude_none=True)
             # Convert include list to comma-separated string
-            if "include" in params and params["include"]:
+            if "include" in params and params["include"] and options.include:
                 params["include"] = ",".join([i.value for i in options.include])
 
         path = f"/api/v2/workspaces/{workspace_id}/queries"
@@ -59,27 +60,27 @@ class QueryRuns(_Service):
     def create(self, options: QueryRunCreateOptions) -> QueryRun:
         """Create a new query run."""
         attrs = options.model_dump(by_alias=True, exclude_none=True)
-        
+
         # Build relationships
         relationships: dict[str, Any] = {}
-        
+
         if workspace_id := attrs.pop("workspace-id", None):
             relationships["workspace"] = {
                 "data": {"type": "workspaces", "id": workspace_id}
             }
-        
+
         if config_version_id := attrs.pop("configuration-version-id", None):
             relationships["configuration-version"] = {
                 "data": {"type": "configuration-versions", "id": config_version_id}
             }
-        
+
         body: dict[str, Any] = {
             "data": {
                 "type": "queries",
                 "attributes": attrs,
             }
         }
-        
+
         if relationships:
             body["data"]["relationships"] = relationships
 
@@ -119,7 +120,7 @@ class QueryRuns(_Service):
 
         params = options.model_dump(by_alias=True, exclude_none=True)
         # Convert include list to comma-separated string
-        if "include" in params and params["include"]:
+        if "include" in params and params["include"] and options.include:
             params["include"] = ",".join([i.value for i in options.include])
 
         r = self.t.request("GET", f"/api/v2/queries/{query_run_id}", params=params)
@@ -133,7 +134,7 @@ class QueryRuns(_Service):
 
     def logs(self, query_run_id: str) -> io.IOBase:
         """Retrieve the logs for a query run.
-        
+
         Returns an IO stream that can be read to get the log content.
         """
         if not valid_string_id(query_run_id):
@@ -141,13 +142,13 @@ class QueryRuns(_Service):
 
         # First get the query run to retrieve the log read URL
         query_run = self.read(query_run_id)
-        
+
         if not query_run.log_read_url:
             raise ValueError(f"Query run {query_run_id} does not have a log URL")
 
         # Fetch the logs from the URL (absolute URLs are handled by _build_url)
         r = self.t.request("GET", query_run.log_read_url)
-        
+
         # Return the content as a BytesIO stream
         return io.BytesIO(r.content)
 
@@ -155,7 +156,7 @@ class QueryRuns(_Service):
         self, query_run_id: str, options: QueryRunCancelOptions | None = None
     ) -> None:
         """Cancel a query run.
-        
+
         Returns 202 on success with empty body.
         """
         if not valid_string_id(query_run_id):
@@ -177,7 +178,7 @@ class QueryRuns(_Service):
         self, query_run_id: str, options: QueryRunForceCancelOptions | None = None
     ) -> None:
         """Force cancel a query run.
-        
+
         Returns 202 on success with empty body.
         """
         if not valid_string_id(query_run_id):

--- a/src/pytfe/resources/query_run.py
+++ b/src/pytfe/resources/query_run.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import io
-from typing import Any
+from typing import Any, Iterator
 
 from ..errors import (
     InvalidQueryRunIDError,
@@ -12,7 +12,6 @@ from ..models.query_run import (
     QueryRunCancelOptions,
     QueryRunCreateOptions,
     QueryRunForceCancelOptions,
-    QueryRunList,
     QueryRunListOptions,
     QueryRunReadOptions,
 )
@@ -25,39 +24,37 @@ class QueryRuns(_Service):
 
     def list(
         self, workspace_id: str, options: QueryRunListOptions | None = None
-    ) -> QueryRunList:
-        """List query runs for the given workspace."""
+    ) -> Iterator[QueryRun]:
+        """Iterate through all query runs for the given workspace.
+        
+        This method automatically handles pagination and yields QueryRun objects one at a time.
+        
+        Args:
+            workspace_id: The ID of the workspace
+            options: Optional list options (page_size, include, etc.)
+            
+        Yields:
+            QueryRun objects one at a time
+            
+        Example:
+            for query_run in client.query_runs.list(workspace_id):
+                print(f"Query Run: {query_run.id} - Status: {query_run.status}")
+        """
         if not valid_string_id(workspace_id):
             raise InvalidWorkspaceIDError()
 
-        params = (
-            options.model_dump(by_alias=True, exclude_none=True) if options else None
-        )
+        params: dict[str, Any] = {}
+        if options:
+            params = options.model_dump(by_alias=True, exclude_none=True)
+            # Convert include list to comma-separated string
+            if "include" in params and params["include"]:
+                params["include"] = ",".join([i.value for i in options.include])
 
-        r = self.t.request(
-            "GET",
-            f"/api/v2/workspaces/{workspace_id}/queries",
-            params=params,
-        )
-
-        jd = r.json()
-        items = []
-        meta = jd.get("meta", {})
-        pagination = meta.get("pagination", {})
-
-        for d in jd.get("data", []):
-            attrs = d.get("attributes", {})
-            attrs["id"] = d.get("id")
-            items.append(QueryRun.model_validate(attrs))
-
-        return QueryRunList(
-            items=items,
-            current_page=pagination.get("current-page"),
-            total_pages=pagination.get("total-pages"),
-            prev_page=pagination.get("prev-page"),
-            next_page=pagination.get("next-page"),
-            total_count=pagination.get("total-count"),
-        )
+        path = f"/api/v2/workspaces/{workspace_id}/queries"
+        for item in self._list(path, params=params):
+            attrs = item.get("attributes", {})
+            attrs["id"] = item.get("id")
+            yield QueryRun.model_validate(attrs)
 
     def create(self, options: QueryRunCreateOptions) -> QueryRun:
         """Create a new query run."""
@@ -121,6 +118,9 @@ class QueryRuns(_Service):
             raise InvalidQueryRunIDError()
 
         params = options.model_dump(by_alias=True, exclude_none=True)
+        # Convert include list to comma-separated string
+        if "include" in params and params["include"]:
+            params["include"] = ",".join([i.value for i in options.include])
 
         r = self.t.request("GET", f"/api/v2/queries/{query_run_id}", params=params)
 

--- a/src/pytfe/resources/query_run.py
+++ b/src/pytfe/resources/query_run.py
@@ -10,9 +10,7 @@ from ..errors import (
 )
 from ..models.query_run import (
     QueryRun,
-    QueryRunCancelOptions,
     QueryRunCreateOptions,
-    QueryRunForceCancelOptions,
     QueryRunListOptions,
     QueryRunReadOptions,
 )
@@ -152,9 +150,7 @@ class QueryRuns(_Service):
         # Return the content as a BytesIO stream
         return io.BytesIO(r.content)
 
-    def cancel(
-        self, query_run_id: str, options: QueryRunCancelOptions | None = None
-    ) -> None:
+    def cancel(self, query_run_id: str) -> None:
         """Cancel a query run.
 
         Returns 202 on success with empty body.
@@ -162,21 +158,12 @@ class QueryRuns(_Service):
         if not valid_string_id(query_run_id):
             raise InvalidQueryRunIDError()
 
-        body: dict[str, Any] | None = None
-        if options:
-            attrs = options.model_dump(by_alias=True, exclude_none=True)
-            if attrs:
-                body = {"data": {"attributes": attrs}}
-
         self.t.request(
             "POST",
             f"/api/v2/queries/{query_run_id}/actions/cancel",
-            json_body=body,
         )
 
-    def force_cancel(
-        self, query_run_id: str, options: QueryRunForceCancelOptions | None = None
-    ) -> None:
+    def force_cancel(self, query_run_id: str) -> None:
         """Force cancel a query run.
 
         Returns 202 on success with empty body.
@@ -184,14 +171,7 @@ class QueryRuns(_Service):
         if not valid_string_id(query_run_id):
             raise InvalidQueryRunIDError()
 
-        body: dict[str, Any] | None = None
-        if options:
-            attrs = options.model_dump(by_alias=True, exclude_none=True)
-            if attrs:
-                body = {"data": {"attributes": attrs}}
-
         self.t.request(
             "POST",
             f"/api/v2/queries/{query_run_id}/actions/force-cancel",
-            json_body=body,
         )

--- a/src/pytfe/resources/query_run.py
+++ b/src/pytfe/resources/query_run.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import io
 from typing import Any
 
 from ..errors import (
-    InvalidOrgError,
     InvalidQueryRunIDError,
+    InvalidWorkspaceIDError,
 )
 from ..models.query_run import (
     QueryRun,
@@ -13,9 +14,7 @@ from ..models.query_run import (
     QueryRunForceCancelOptions,
     QueryRunList,
     QueryRunListOptions,
-    QueryRunLogs,
     QueryRunReadOptions,
-    QueryRunResults,
 )
 from ..utils import valid_string_id
 from ._base import _Service
@@ -25,11 +24,11 @@ class QueryRuns(_Service):
     """Query Runs API for Terraform Enterprise."""
 
     def list(
-        self, organization: str, options: QueryRunListOptions | None = None
+        self, workspace_id: str, options: QueryRunListOptions | None = None
     ) -> QueryRunList:
-        """List query runs for the given organization."""
-        if not valid_string_id(organization):
-            raise InvalidOrgError()
+        """List query runs for the given workspace."""
+        if not valid_string_id(workspace_id):
+            raise InvalidWorkspaceIDError()
 
         params = (
             options.model_dump(by_alias=True, exclude_none=True) if options else None
@@ -37,7 +36,7 @@ class QueryRuns(_Service):
 
         r = self.t.request(
             "GET",
-            f"/api/v2/organizations/{organization}/query-runs",
+            f"/api/v2/workspaces/{workspace_id}/queries",
             params=params,
         )
 
@@ -60,22 +59,36 @@ class QueryRuns(_Service):
             total_count=pagination.get("total-count"),
         )
 
-    def create(self, organization: str, options: QueryRunCreateOptions) -> QueryRun:
-        """Create a new query run for the given organization."""
-        if not valid_string_id(organization):
-            raise InvalidOrgError()
-
+    def create(self, options: QueryRunCreateOptions) -> QueryRun:
+        """Create a new query run."""
         attrs = options.model_dump(by_alias=True, exclude_none=True)
+        
+        # Build relationships
+        relationships: dict[str, Any] = {}
+        
+        if workspace_id := attrs.pop("workspace-id", None):
+            relationships["workspace"] = {
+                "data": {"type": "workspaces", "id": workspace_id}
+            }
+        
+        if config_version_id := attrs.pop("configuration-version-id", None):
+            relationships["configuration-version"] = {
+                "data": {"type": "configuration-versions", "id": config_version_id}
+            }
+        
         body: dict[str, Any] = {
             "data": {
+                "type": "queries",
                 "attributes": attrs,
-                "type": "query-runs",
             }
         }
+        
+        if relationships:
+            body["data"]["relationships"] = relationships
 
         r = self.t.request(
             "POST",
-            f"/api/v2/organizations/{organization}/query-runs",
+            "/api/v2/queries",
             json_body=body,
         )
 
@@ -91,7 +104,7 @@ class QueryRuns(_Service):
         if not valid_string_id(query_run_id):
             raise InvalidQueryRunIDError()
 
-        r = self.t.request("GET", f"/api/v2/query-runs/{query_run_id}")
+        r = self.t.request("GET", f"/api/v2/queries/{query_run_id}")
 
         jd = r.json()
         data = jd.get("data", {})
@@ -109,7 +122,7 @@ class QueryRuns(_Service):
 
         params = options.model_dump(by_alias=True, exclude_none=True)
 
-        r = self.t.request("GET", f"/api/v2/query-runs/{query_run_id}", params=params)
+        r = self.t.request("GET", f"/api/v2/queries/{query_run_id}", params=params)
 
         jd = r.json()
         data = jd.get("data", {})
@@ -118,99 +131,66 @@ class QueryRuns(_Service):
 
         return QueryRun.model_validate(attrs)
 
-    def logs(self, query_run_id: str) -> QueryRunLogs:
-        """Retrieve the logs for a query run."""
+    def logs(self, query_run_id: str) -> io.IOBase:
+        """Retrieve the logs for a query run.
+        
+        Returns an IO stream that can be read to get the log content.
+        """
         if not valid_string_id(query_run_id):
             raise InvalidQueryRunIDError()
 
-        r = self.t.request("GET", f"/api/v2/query-runs/{query_run_id}/logs")
+        # First get the query run to retrieve the log read URL
+        query_run = self.read(query_run_id)
+        
+        if not query_run.log_read_url:
+            raise ValueError(f"Query run {query_run_id} does not have a log URL")
 
-        # Handle both JSON and plain text responses
-        content_type = r.headers.get("content-type", "").lower()
-
-        if "application/json" in content_type:
-            jd = r.json()
-            return QueryRunLogs.model_validate(jd.get("data", {}))
-        else:
-            # Plain text logs
-            return QueryRunLogs(
-                query_run_id=query_run_id,
-                logs=r.text,
-                log_level="info",
-                timestamp=None,
-            )
-
-    def results(self, query_run_id: str) -> QueryRunResults:
-        """Retrieve the results for a query run."""
-        if not valid_string_id(query_run_id):
-            raise InvalidQueryRunIDError()
-
-        r = self.t.request("GET", f"/api/v2/query-runs/{query_run_id}/results")
-
-        jd = r.json()
-        data = jd.get("data", {})
-
-        return QueryRunResults(
-            query_run_id=query_run_id,
-            results=data.get("results", []),
-            total_count=data.get("total_count", 0),
-            truncated=data.get("truncated", False),
-        )
+        # Fetch the logs from the URL (absolute URLs are handled by _build_url)
+        r = self.t.request("GET", query_run.log_read_url)
+        
+        # Return the content as a BytesIO stream
+        return io.BytesIO(r.content)
 
     def cancel(
         self, query_run_id: str, options: QueryRunCancelOptions | None = None
-    ) -> QueryRun:
-        """Cancel a query run."""
+    ) -> None:
+        """Cancel a query run.
+        
+        Returns 202 on success with empty body.
+        """
         if not valid_string_id(query_run_id):
             raise InvalidQueryRunIDError()
 
-        attrs = options.model_dump(by_alias=True, exclude_none=True) if options else {}
+        body: dict[str, Any] | None = None
+        if options:
+            attrs = options.model_dump(by_alias=True, exclude_none=True)
+            if attrs:
+                body = {"data": {"attributes": attrs}}
 
-        body: dict[str, Any] = {
-            "data": {
-                "attributes": attrs,
-                "type": "query-runs",
-            }
-        }
-
-        r = self.t.request(
+        self.t.request(
             "POST",
-            f"/api/v2/query-runs/{query_run_id}/actions/cancel",
+            f"/api/v2/queries/{query_run_id}/actions/cancel",
             json_body=body,
         )
-
-        jd = r.json()
-        data = jd.get("data", {})
-        attrs = data.get("attributes", {})
-        attrs["id"] = data.get("id")
-
-        return QueryRun.model_validate(attrs)
 
     def force_cancel(
         self, query_run_id: str, options: QueryRunForceCancelOptions | None = None
-    ) -> QueryRun:
-        """Force cancel a query run."""
+    ) -> None:
+        """Force cancel a query run.
+        
+        Returns 202 on success with empty body.
+        """
         if not valid_string_id(query_run_id):
             raise InvalidQueryRunIDError()
 
-        attrs = options.model_dump(by_alias=True, exclude_none=True) if options else {}
+        body: dict[str, Any] | None = None
+        if options:
+            attrs = options.model_dump(by_alias=True, exclude_none=True)
+            if attrs:
+                body = {"data": {"attributes": attrs}}
 
-        body: dict[str, Any] = {
-            "data": {
-                "attributes": attrs,
-                "type": "query-runs",
-            }
-        }
-
-        r = self.t.request(
+        self.t.request(
             "POST",
-            f"/api/v2/query-runs/{query_run_id}/actions/force-cancel",
+            f"/api/v2/queries/{query_run_id}/actions/force-cancel",
             json_body=body,
         )
-
-        jd = r.json()
-        data = jd.get("data", {})
-        attrs = data.get("attributes", {})
-        attrs["id"] = data.get("id")
-
-        return QueryRun.model_validate(attrs)

--- a/tests/units/test_query_run.py
+++ b/tests/units/test_query_run.py
@@ -21,9 +21,7 @@ import pytest
 from pytfe.errors import InvalidQueryRunIDError, InvalidWorkspaceIDError
 from pytfe.models import (
     QueryRun,
-    QueryRunCancelOptions,
     QueryRunCreateOptions,
-    QueryRunForceCancelOptions,
     QueryRunIncludeOpt,
     QueryRunListOptions,
     QueryRunReadOptions,
@@ -431,26 +429,6 @@ class TestQueryRunsCancel:
         mock_transport.request.assert_called_once_with(
             "POST",
             "/api/v2/queries/qr-123abc456def/actions/cancel",
-            json_body=None,
-        )
-
-    def test_cancel_with_comment(self, query_runs_service, mock_transport):
-        """Test cancellation with comment."""
-        mock_response = Mock()
-        mock_transport.request.return_value = mock_response
-
-        options = QueryRunCancelOptions(comment="Canceling due to configuration error")
-
-        query_runs_service.cancel("qr-123abc456def", options)
-
-        # Verify the request includes comment
-        call_args = mock_transport.request.call_args
-        assert call_args[0][0] == "POST"
-        assert call_args[0][1] == "/api/v2/queries/qr-123abc456def/actions/cancel"
-        json_body = call_args[1]["json_body"]
-        assert (
-            json_body["data"]["attributes"]["comment"]
-            == "Canceling due to configuration error"
         )
 
     def test_cancel_invalid_id(self, query_runs_service):
@@ -478,26 +456,6 @@ class TestQueryRunsForceCancel:
         mock_transport.request.assert_called_once_with(
             "POST",
             "/api/v2/queries/qr-123abc456def/actions/force-cancel",
-            json_body=None,
-        )
-
-    def test_force_cancel_with_comment(self, query_runs_service, mock_transport):
-        """Test force cancellation with comment."""
-        mock_response = Mock()
-        mock_transport.request.return_value = mock_response
-
-        options = QueryRunForceCancelOptions(comment="Force canceling stuck query run")
-
-        query_runs_service.force_cancel("qr-123abc456def", options)
-
-        # Verify the request includes comment
-        call_args = mock_transport.request.call_args
-        assert call_args[0][0] == "POST"
-        assert call_args[0][1] == "/api/v2/queries/qr-123abc456def/actions/force-cancel"
-        json_body = call_args[1]["json_body"]
-        assert (
-            json_body["data"]["attributes"]["comment"]
-            == "Force canceling stuck query run"
         )
 
     def test_force_cancel_invalid_id(self, query_runs_service):

--- a/tests/units/test_query_run.py
+++ b/tests/units/test_query_run.py
@@ -34,7 +34,6 @@ from pytfe.models import (
 )
 from pytfe.resources.query_run import QueryRuns
 
-
 # ============================================================================
 # Fixtures
 # ============================================================================
@@ -157,7 +156,7 @@ class TestQueryRunsList:
 
         # Verify the results
         assert len(query_runs) == 2
-        
+
         # Check first query run
         qr1 = query_runs[0]
         assert qr1.id == "qr-123abc456def"
@@ -167,7 +166,7 @@ class TestQueryRunsList:
         assert len(qr1.variables) == 2
         assert qr1.variables[0].key == "environment"
         assert qr1.variables[0].value == "production"
-        
+
         # Check second query run
         qr2 = query_runs[1]
         assert qr2.id == "qr-789ghi012jkl"
@@ -187,9 +186,12 @@ class TestQueryRunsList:
         options = QueryRunListOptions(
             page_number=1,
             page_size=10,
-            include=[QueryRunIncludeOpt.CREATED_BY, QueryRunIncludeOpt.CONFIGURATION_VERSION],
+            include=[
+                QueryRunIncludeOpt.CREATED_BY,
+                QueryRunIncludeOpt.CONFIGURATION_VERSION,
+            ],
         )
-        
+
         query_runs = list(query_runs_service.list(workspace_id, options))
 
         # Verify the request includes options
@@ -220,7 +222,9 @@ class TestQueryRunsList:
 class TestQueryRunsCreate:
     """Test suite for query run create operations."""
 
-    def test_create_basic(self, query_runs_service, mock_transport, sample_query_run_data):
+    def test_create_basic(
+        self, query_runs_service, mock_transport, sample_query_run_data
+    ):
         """Test basic query run creation."""
         mock_response = Mock()
         mock_response.json.return_value = {"data": sample_query_run_data}
@@ -238,12 +242,17 @@ class TestQueryRunsCreate:
         call_args = mock_transport.request.call_args
         assert call_args[0][0] == "POST"
         assert call_args[0][1] == "/api/v2/queries"
-        
+
         json_body = call_args[1]["json_body"]
         assert json_body["data"]["type"] == "queries"
         assert json_body["data"]["attributes"]["source"] == "tfe-api"
-        assert json_body["data"]["relationships"]["workspace"]["data"]["id"] == "ws-abc123"
-        assert json_body["data"]["relationships"]["configuration-version"]["data"]["id"] == "cv-def456"
+        assert (
+            json_body["data"]["relationships"]["workspace"]["data"]["id"] == "ws-abc123"
+        )
+        assert (
+            json_body["data"]["relationships"]["configuration-version"]["data"]["id"]
+            == "cv-def456"
+        )
 
         # Verify the result
         assert isinstance(result, QueryRun)
@@ -292,7 +301,9 @@ class TestQueryRunsCreate:
 class TestQueryRunsRead:
     """Test suite for query run read operations."""
 
-    def test_read_success(self, query_runs_service, mock_transport, sample_query_run_data):
+    def test_read_success(
+        self, query_runs_service, mock_transport, sample_query_run_data
+    ):
         """Test successful query run read."""
         mock_response = Mock()
         mock_response.json.return_value = {"data": sample_query_run_data}
@@ -329,7 +340,10 @@ class TestQueryRunsRead:
         mock_transport.request.return_value = mock_response
 
         options = QueryRunReadOptions(
-            include=[QueryRunIncludeOpt.CREATED_BY, QueryRunIncludeOpt.CONFIGURATION_VERSION]
+            include=[
+                QueryRunIncludeOpt.CREATED_BY,
+                QueryRunIncludeOpt.CONFIGURATION_VERSION,
+            ]
         )
 
         result = query_runs_service.read_with_options("qr-123abc456def", options)
@@ -357,7 +371,9 @@ class TestQueryRunsLogs:
         """Test successful logs retrieval."""
         # Mock the read method to return a query run with log URL
         mock_query_run = Mock()
-        mock_query_run.log_read_url = "https://app.terraform.io/api/v2/queries/qr-123/logs"
+        mock_query_run.log_read_url = (
+            "https://app.terraform.io/api/v2/queries/qr-123/logs"
+        )
 
         # Mock the logs content
         mock_logs_response = Mock()
@@ -365,7 +381,7 @@ class TestQueryRunsLogs:
 
         with patch.object(query_runs_service, "read", return_value=mock_query_run):
             mock_transport.request.return_value = mock_logs_response
-            
+
             result = query_runs_service.logs("qr-123abc456def")
 
             # Verify read was called
@@ -432,7 +448,10 @@ class TestQueryRunsCancel:
         assert call_args[0][0] == "POST"
         assert call_args[0][1] == "/api/v2/queries/qr-123abc456def/actions/cancel"
         json_body = call_args[1]["json_body"]
-        assert json_body["data"]["attributes"]["comment"] == "Canceling due to configuration error"
+        assert (
+            json_body["data"]["attributes"]["comment"]
+            == "Canceling due to configuration error"
+        )
 
     def test_cancel_invalid_id(self, query_runs_service):
         """Test cancel with invalid query run ID."""
@@ -476,7 +495,10 @@ class TestQueryRunsForceCancel:
         assert call_args[0][0] == "POST"
         assert call_args[0][1] == "/api/v2/queries/qr-123abc456def/actions/force-cancel"
         json_body = call_args[1]["json_body"]
-        assert json_body["data"]["attributes"]["comment"] == "Force canceling stuck query run"
+        assert (
+            json_body["data"]["attributes"]["comment"]
+            == "Force canceling stuck query run"
+        )
 
     def test_force_cancel_invalid_id(self, query_runs_service):
         """Test force cancel with invalid query run ID."""

--- a/tests/units/test_query_run.py
+++ b/tests/units/test_query_run.py
@@ -1,19 +1,30 @@
-from datetime import datetime
-from unittest.mock import MagicMock, Mock
-import io
+"""
+Comprehensive unit tests for query run operations in the Python TFE SDK.
+
+This test suite covers all query run methods including:
+1. list() - List query runs for a workspace with pagination
+2. create() - Create new query runs
+3. read() - Read query run details
+4. read_with_options() - Read with include options
+5. logs() - Retrieve query run logs
+6. cancel() - Cancel a query run
+7. force_cancel() - Force cancel a query run
+
+Usage:
+    pytest tests/units/test_query_run.py -v
+"""
+
+from unittest.mock import Mock, patch
 
 import pytest
 
-from pytfe import TFEClient, TFEConfig
 from pytfe.errors import InvalidQueryRunIDError, InvalidWorkspaceIDError
-from pytfe.models.query_run import (
+from pytfe.models import (
     QueryRun,
-    QueryRunActions,
     QueryRunCancelOptions,
     QueryRunCreateOptions,
     QueryRunForceCancelOptions,
     QueryRunIncludeOpt,
-    QueryRunList,
     QueryRunListOptions,
     QueryRunReadOptions,
     QueryRunSource,
@@ -21,357 +32,540 @@ from pytfe.models.query_run import (
     QueryRunStatusTimestamps,
     QueryRunVariable,
 )
+from pytfe.resources.query_run import QueryRuns
 
 
-class TestQueryRunModels:
-    """Test query run models and validation."""
-
-    def test_query_run_model_basic(self):
-        """Test basic QueryRun model creation."""
-        query_run = QueryRun(
-            id="query-test123",
-            source=QueryRunSource.API,
-            status=QueryRunStatus.PENDING,
-            created_at=datetime.now(),
-            updated_at=datetime.now(),
-        )
-        assert query_run.id == "query-test123"
-        assert query_run.source == QueryRunSource.API
-        assert query_run.status == QueryRunStatus.PENDING
-
-    def test_query_run_status_enum(self):
-        """Test QueryRunStatus enum values."""
-        assert QueryRunStatus.PENDING == "pending"
-        assert QueryRunStatus.QUEUED == "queued"
-        assert QueryRunStatus.RUNNING == "running"
-        assert QueryRunStatus.FINISHED == "finished"
-        assert QueryRunStatus.ERRORED == "errored"
-        assert QueryRunStatus.CANCELED == "canceled"
-
-    def test_query_run_source_enum(self):
-        """Test QueryRunSource enum values."""
-        assert QueryRunSource.API == "tfe-api"
-
-    def test_query_run_create_options(self):
-        """Test QueryRunCreateOptions model."""
-        options = QueryRunCreateOptions(
-            source=QueryRunSource.API,
-            workspace_id="ws-test123",
-        )
-        assert options.source == QueryRunSource.API
-        assert options.workspace_id == "ws-test123"
-
-    def test_query_run_list_options(self):
-        """Test QueryRunListOptions model."""
-        options = QueryRunListOptions(
-            page_number=2,
-            page_size=50,
-            include=[QueryRunIncludeOpt.CREATED_BY],
-        )
-        assert options.page_number == 2
-        assert options.page_size == 50
-        assert QueryRunIncludeOpt.CREATED_BY in options.include
-
-    def test_query_run_actions(self):
-        """Test QueryRunActions model."""
-        actions = QueryRunActions(
-            is_cancelable=True,
-            is_force_cancelable=False,
-        )
-        assert actions.is_cancelable is True
-        assert actions.is_force_cancelable is False
+# ============================================================================
+# Fixtures
+# ============================================================================
 
 
-class TestQueryRunOperations:
-    """Test query run operations."""
+@pytest.fixture
+def mock_transport():
+    """Create a mock HTTPTransport."""
+    return Mock()
 
-    @pytest.fixture
-    def client(self):
-        """Create a test client."""
-        config = TFEConfig(address="https://test.terraform.io", token="test-token")
-        return TFEClient(config)
 
-    @pytest.fixture
-    def mock_list_response(self):
-        """Create a mock list response."""
-        mock = Mock()
-        mock.json.return_value = {
-            "data": [
-                {
-                    "id": "query-test123",
-                    "type": "queries",
-                    "attributes": {
-                        "source": "tfe-api",
-                        "status": "finished",
-                        "created-at": "2023-01-01T00:00:00Z",
-                        "updated-at": "2023-01-01T00:05:00Z",
-                        "log-read-url": "https://archivist.terraform.io/v1/object/...",
-                    },
-                }
+@pytest.fixture
+def query_runs_service(mock_transport):
+    """Create a QueryRuns service with mocked transport."""
+    return QueryRuns(mock_transport)
+
+
+@pytest.fixture
+def sample_query_run_data():
+    """Sample query run data from API."""
+    return {
+        "id": "qr-123abc456def",
+        "type": "queries",
+        "attributes": {
+            "source": "tfe-api",
+            "status": "finished",
+            "created-at": "2024-01-15T10:00:00Z",
+            "updated-at": "2024-01-15T10:05:00Z",
+            "canceled-at": None,
+            "log-read-url": "https://app.terraform.io/api/v2/queries/qr-123abc456def/logs",
+            "status-timestamps": {
+                "queued-at": "2024-01-15T10:00:00Z",
+                "running-at": "2024-01-15T10:01:00Z",
+                "finished-at": "2024-01-15T10:05:00Z",
+            },
+            "variables": [
+                {"key": "environment", "value": "production"},
+                {"key": "region", "value": "us-east-1"},
             ],
-            "meta": {
-                "pagination": {
-                    "current-page": 1,
-                    "total-pages": 1,
-                    "prev-page": None,
-                    "next-page": None,
-                    "total-count": 1,
-                }
+            "actions": {
+                "is-cancelable": True,
+                "is-force-cancelable": False,
             },
-        }
-        return mock
-
-    def test_list_query_runs(self, client, mock_list_response):
-        """Test listing query runs."""
-        client._transport.request = MagicMock(return_value=mock_list_response)
-
-        result = client.query_runs.list("ws-test123")
-
-        assert isinstance(result, QueryRunList)
-        assert len(result.items) == 1
-        assert result.items[0].id == "query-test123"
-        assert result.items[0].source == QueryRunSource.API
-        assert result.current_page == 1
-        assert result.total_count == 1
-
-        client._transport.request.assert_called_once_with(
-            "GET", "/api/v2/workspaces/ws-test123/queries", params=None
-        )
-
-    def test_list_query_runs_with_options(self, client, mock_list_response):
-        """Test listing query runs with options."""
-        client._transport.request = MagicMock(return_value=mock_list_response)
-
-        options = QueryRunListOptions(
-            page_number=2,
-            page_size=25,
-            include=[QueryRunIncludeOpt.CREATED_BY],
-        )
-        result = client.query_runs.list("ws-test123", options)
-
-        assert isinstance(result, QueryRunList)
-        client._transport.request.assert_called_once_with(
-            "GET",
-            "/api/v2/workspaces/ws-test123/queries",
-            params={
-                "page[number]": 2,
-                "page[size]": 25,
-                "include": [QueryRunIncludeOpt.CREATED_BY],
+        },
+        "relationships": {
+            "workspace": {"data": {"id": "ws-abc123", "type": "workspaces"}},
+            "configuration-version": {
+                "data": {"id": "cv-def456", "type": "configuration-versions"}
             },
-        )
+            "created-by": {"data": {"id": "user-123", "type": "users"}},
+        },
+    }
 
-    def test_list_invalid_workspace_id(self, client):
-        """Test listing query runs with invalid workspace ID."""
-        with pytest.raises(InvalidWorkspaceIDError):
-            client.query_runs.list("")
 
-    def test_create_query_run(self, client):
-        """Test creating a query run."""
-        mock_response = Mock()
-        mock_response.json.return_value = {
-            "data": {
-                "id": "query-new123",
+@pytest.fixture
+def sample_query_run_list_response(sample_query_run_data):
+    """Sample query run list response."""
+    return {
+        "data": [
+            sample_query_run_data,
+            {
+                "id": "qr-789ghi012jkl",
                 "type": "queries",
                 "attributes": {
                     "source": "tfe-api",
-                    "status": "pending",
-                    "created-at": "2023-01-01T00:00:00Z",
-                    "updated-at": "2023-01-01T00:00:00Z",
-                },
-            }
-        }
-        client._transport.request = MagicMock(return_value=mock_response)
-
-        options = QueryRunCreateOptions(
-            source=QueryRunSource.API,
-            workspace_id="ws-test123",
-        )
-        result = client.query_runs.create(options)
-
-        assert isinstance(result, QueryRun)
-        assert result.id == "query-new123"
-        assert result.source == QueryRunSource.API
-        assert result.status == QueryRunStatus.PENDING
-
-        # Verify the call was made with correct structure
-        call_args = client._transport.request.call_args
-        assert call_args[0][0] == "POST"
-        assert call_args[0][1] == "/api/v2/queries"
-        json_body = call_args[1]["json_body"]
-        assert json_body["data"]["type"] == "queries"
-        assert "relationships" in json_body["data"]
-        assert json_body["data"]["relationships"]["workspace"]["data"]["id"] == "ws-test123"
-
-    def test_read_query_run(self, client):
-        """Test reading a query run."""
-        mock_response = Mock()
-        mock_response.json.return_value = {
-            "data": {
-                "id": "query-test123",
-                "type": "queries",
-                "attributes": {
-                    "source": "tfe-api",
-                    "status": "finished",
-                    "created-at": "2023-01-01T00:00:00Z",
-                    "updated-at": "2023-01-01T00:05:00Z",
-                    "log-read-url": "https://archivist.terraform.io/v1/object/...",
+                    "status": "running",
+                    "created-at": "2024-01-15T11:00:00Z",
+                    "updated-at": "2024-01-15T11:02:00Z",
+                    "canceled-at": None,
+                    "log-read-url": None,
+                    "status-timestamps": {
+                        "queued-at": "2024-01-15T11:00:00Z",
+                        "running-at": "2024-01-15T11:01:00Z",
+                    },
+                    "variables": [],
                     "actions": {
-                        "is-cancelable": False,
+                        "is-cancelable": True,
                         "is-force-cancelable": False,
                     },
                 },
+            },
+        ],
+        "meta": {
+            "pagination": {
+                "current-page": 1,
+                "page-size": 20,
+                "total-pages": 1,
+                "total-count": 2,
             }
-        }
-        client._transport.request = MagicMock(return_value=mock_response)
+        },
+        "links": {"next": None},
+    }
 
-        result = client.query_runs.read("query-test123")
 
-        assert isinstance(result, QueryRun)
-        assert result.id == "query-test123"
-        assert result.status == QueryRunStatus.FINISHED
+# ============================================================================
+# List Operations Tests
+# ============================================================================
 
-        client._transport.request.assert_called_once_with(
-            "GET", "/api/v2/queries/query-test123"
+
+class TestQueryRunsList:
+    """Test suite for query run list operations."""
+
+    def test_list_basic(
+        self, query_runs_service, mock_transport, sample_query_run_list_response
+    ):
+        """Test basic query run listing."""
+        mock_response = Mock()
+        mock_response.json.return_value = sample_query_run_list_response
+        mock_transport.request.return_value = mock_response
+
+        workspace_id = "ws-abc123"
+        query_runs = list(query_runs_service.list(workspace_id))
+
+        # Verify the request
+        mock_transport.request.assert_called_with(
+            "GET",
+            f"/api/v2/workspaces/{workspace_id}/queries",
+            params={"page[number]": 1, "page[size]": 100},
         )
 
-    def test_read_query_run_with_options(self, client):
-        """Test reading a query run with options."""
+        # Verify the results
+        assert len(query_runs) == 2
+        
+        # Check first query run
+        qr1 = query_runs[0]
+        assert qr1.id == "qr-123abc456def"
+        assert qr1.status == QueryRunStatus.FINISHED
+        assert qr1.source == QueryRunSource.API
+        assert qr1.log_read_url is not None
+        assert len(qr1.variables) == 2
+        assert qr1.variables[0].key == "environment"
+        assert qr1.variables[0].value == "production"
+        
+        # Check second query run
+        qr2 = query_runs[1]
+        assert qr2.id == "qr-789ghi012jkl"
+        assert qr2.status == QueryRunStatus.RUNNING
+        assert qr2.log_read_url is None
+        assert len(qr2.variables) == 0
+
+    def test_list_with_options(
+        self, query_runs_service, mock_transport, sample_query_run_list_response
+    ):
+        """Test list with options."""
         mock_response = Mock()
-        mock_response.json.return_value = {
-            "data": {
-                "id": "query-test123",
-                "type": "queries",
-                "attributes": {
-                    "source": "tfe-api",
-                    "status": "finished",
-                    "created-at": "2023-01-01T00:00:00Z",
-                    "updated-at": "2023-01-01T00:05:00Z",
-                },
-            }
-        }
-        client._transport.request = MagicMock(return_value=mock_response)
+        mock_response.json.return_value = sample_query_run_list_response
+        mock_transport.request.return_value = mock_response
+
+        workspace_id = "ws-abc123"
+        options = QueryRunListOptions(
+            page_number=1,
+            page_size=10,
+            include=[QueryRunIncludeOpt.CREATED_BY, QueryRunIncludeOpt.CONFIGURATION_VERSION],
+        )
+        
+        query_runs = list(query_runs_service.list(workspace_id, options))
+
+        # Verify the request includes options
+        call_args = mock_transport.request.call_args
+        assert call_args[0][0] == "GET"
+        assert call_args[0][1] == f"/api/v2/workspaces/{workspace_id}/queries"
+        params = call_args[1]["params"]
+        assert params["page[number]"] == 1
+        assert params["page[size]"] == 10
+        assert params["include"] == "created_by,configuration_version"
+
+        assert len(query_runs) == 2
+
+    def test_list_invalid_workspace_id(self, query_runs_service):
+        """Test list with invalid workspace ID."""
+        with pytest.raises(InvalidWorkspaceIDError):
+            list(query_runs_service.list(""))
+
+        with pytest.raises(InvalidWorkspaceIDError):
+            list(query_runs_service.list(None))
+
+
+# ============================================================================
+# Create Operations Tests
+# ============================================================================
+
+
+class TestQueryRunsCreate:
+    """Test suite for query run create operations."""
+
+    def test_create_basic(self, query_runs_service, mock_transport, sample_query_run_data):
+        """Test basic query run creation."""
+        mock_response = Mock()
+        mock_response.json.return_value = {"data": sample_query_run_data}
+        mock_transport.request.return_value = mock_response
+
+        options = QueryRunCreateOptions(
+            source=QueryRunSource.API,
+            workspace_id="ws-abc123",
+            configuration_version_id="cv-def456",
+        )
+
+        result = query_runs_service.create(options)
+
+        # Verify the request
+        call_args = mock_transport.request.call_args
+        assert call_args[0][0] == "POST"
+        assert call_args[0][1] == "/api/v2/queries"
+        
+        json_body = call_args[1]["json_body"]
+        assert json_body["data"]["type"] == "queries"
+        assert json_body["data"]["attributes"]["source"] == "tfe-api"
+        assert json_body["data"]["relationships"]["workspace"]["data"]["id"] == "ws-abc123"
+        assert json_body["data"]["relationships"]["configuration-version"]["data"]["id"] == "cv-def456"
+
+        # Verify the result
+        assert isinstance(result, QueryRun)
+        assert result.id == "qr-123abc456def"
+        assert result.status == QueryRunStatus.FINISHED
+        assert result.source == QueryRunSource.API
+
+    def test_create_with_variables(
+        self, query_runs_service, mock_transport, sample_query_run_data
+    ):
+        """Test query run creation with variables."""
+        mock_response = Mock()
+        mock_response.json.return_value = {"data": sample_query_run_data}
+        mock_transport.request.return_value = mock_response
+
+        variables = [
+            QueryRunVariable(key="environment", value="production"),
+            QueryRunVariable(key="region", value="us-east-1"),
+        ]
+
+        options = QueryRunCreateOptions(
+            source=QueryRunSource.API,
+            workspace_id="ws-abc123",
+            configuration_version_id="cv-def456",
+            variables=variables,
+        )
+
+        result = query_runs_service.create(options)
+
+        # Verify variables in request
+        call_args = mock_transport.request.call_args
+        json_body = call_args[1]["json_body"]
+        assert "variables" in json_body["data"]["attributes"]
+        assert len(json_body["data"]["attributes"]["variables"]) == 2
+
+        # Verify result
+        assert result.id == "qr-123abc456def"
+        assert len(result.variables) == 2
+
+
+# ============================================================================
+# Read Operations Tests
+# ============================================================================
+
+
+class TestQueryRunsRead:
+    """Test suite for query run read operations."""
+
+    def test_read_success(self, query_runs_service, mock_transport, sample_query_run_data):
+        """Test successful query run read."""
+        mock_response = Mock()
+        mock_response.json.return_value = {"data": sample_query_run_data}
+        mock_transport.request.return_value = mock_response
+
+        result = query_runs_service.read("qr-123abc456def")
+
+        # Verify the request
+        mock_transport.request.assert_called_once_with(
+            "GET", "/api/v2/queries/qr-123abc456def"
+        )
+
+        # Verify the result
+        assert isinstance(result, QueryRun)
+        assert result.id == "qr-123abc456def"
+        assert result.status == QueryRunStatus.FINISHED
+        assert result.source == QueryRunSource.API
+        assert result.log_read_url is not None
+
+    def test_read_invalid_id(self, query_runs_service):
+        """Test read with invalid query run ID."""
+        with pytest.raises(InvalidQueryRunIDError):
+            query_runs_service.read("")
+
+        with pytest.raises(InvalidQueryRunIDError):
+            query_runs_service.read(None)
+
+    def test_read_with_options_success(
+        self, query_runs_service, mock_transport, sample_query_run_data
+    ):
+        """Test read with options."""
+        mock_response = Mock()
+        mock_response.json.return_value = {"data": sample_query_run_data}
+        mock_transport.request.return_value = mock_response
 
         options = QueryRunReadOptions(
             include=[QueryRunIncludeOpt.CREATED_BY, QueryRunIncludeOpt.CONFIGURATION_VERSION]
         )
-        result = client.query_runs.read_with_options("query-test123", options)
 
-        assert isinstance(result, QueryRun)
-        assert result.id == "query-test123"
+        result = query_runs_service.read_with_options("qr-123abc456def", options)
 
-        client._transport.request.assert_called_once_with(
-            "GET",
-            "/api/v2/queries/query-test123",
-            params={"include": [QueryRunIncludeOpt.CREATED_BY, QueryRunIncludeOpt.CONFIGURATION_VERSION]},
-        )
+        # Verify the request includes options
+        call_args = mock_transport.request.call_args
+        assert call_args[0][0] == "GET"
+        assert call_args[0][1] == "/api/v2/queries/qr-123abc456def"
+        params = call_args[1]["params"]
+        assert params["include"] == "created_by,configuration_version"
 
-    def test_read_invalid_query_run_id(self, client):
-        """Test reading with invalid query run ID."""
-        with pytest.raises(InvalidQueryRunIDError):
-            client.query_runs.read("")
+        # Verify the result
+        assert result.id == "qr-123abc456def"
 
-    def test_query_run_logs(self, client):
-        """Test retrieving query run logs."""
-        # Mock the read call first
-        mock_read_response = Mock()
-        mock_read_response.json.return_value = {
-            "data": {
-                "id": "query-test123",
-                "type": "queries",
-                "attributes": {
-                    "source": "tfe-api",
-                    "status": "finished",
-                    "created-at": "2023-01-01T00:00:00Z",
-                    "updated-at": "2023-01-01T00:05:00Z",
-                    "log-read-url": "https://archivist.terraform.io/v1/object/dmF1bHQ6djE6L...",
-                },
-            }
-        }
-        
-        # Mock the logs fetch
+
+# ============================================================================
+# Logs Operations Tests
+# ============================================================================
+
+
+class TestQueryRunsLogs:
+    """Test suite for query run logs operations."""
+
+    def test_logs_success(self, query_runs_service, mock_transport):
+        """Test successful logs retrieval."""
+        # Mock the read method to return a query run with log URL
+        mock_query_run = Mock()
+        mock_query_run.log_read_url = "https://app.terraform.io/api/v2/queries/qr-123/logs"
+
+        # Mock the logs content
         mock_logs_response = Mock()
-        mock_logs_response.content = b"Starting query execution...\nQuery completed successfully."
-        
-        client._transport.request = MagicMock(side_effect=[mock_read_response, mock_logs_response])
+        mock_logs_response.content = b"Query run logs content\nLine 2\nLine 3"
 
-        result = client.query_runs.logs("query-test123")
+        with patch.object(query_runs_service, "read", return_value=mock_query_run):
+            mock_transport.request.return_value = mock_logs_response
+            
+            result = query_runs_service.logs("qr-123abc456def")
 
-        assert isinstance(result, io.IOBase)
-        log_content = result.read()
-        assert b"Starting query execution" in log_content
+            # Verify read was called
+            query_runs_service.read.assert_called_once_with("qr-123abc456def")
 
-        # Verify calls
-        assert client._transport.request.call_count == 2
+            # Verify logs request was made
+            mock_transport.request.assert_called_once_with(
+                "GET", "https://app.terraform.io/api/v2/queries/qr-123/logs"
+            )
 
-    def test_query_run_logs_no_url(self, client):
-        """Test retrieving logs when no log URL is available."""
-        mock_read_response = Mock()
-        mock_read_response.json.return_value = {
-            "data": {
-                "id": "query-test123",
-                "type": "queries",
-                "attributes": {
-                    "source": "tfe-api",
-                    "status": "pending",
-                    "created-at": "2023-01-01T00:00:00Z",
-                    "updated-at": "2023-01-01T00:00:00Z",
-                },
-            }
-        }
-        
-        client._transport.request = MagicMock(return_value=mock_read_response)
+            # Verify the result is an IO stream
+            assert result.read() == b"Query run logs content\nLine 2\nLine 3"
 
-        with pytest.raises(ValueError, match="does not have a log URL"):
-            client.query_runs.logs("query-test123")
+    def test_logs_no_url_error(self, query_runs_service):
+        """Test logs method when query run has no log URL."""
+        mock_query_run = Mock()
+        mock_query_run.log_read_url = None
 
-    def test_cancel_query_run(self, client):
-        """Test canceling a query run."""
+        with patch.object(query_runs_service, "read", return_value=mock_query_run):
+            with pytest.raises(ValueError) as exc:
+                query_runs_service.logs("qr-123abc456def")
+
+            assert "does not have a log URL" in str(exc.value)
+
+    def test_logs_invalid_id(self, query_runs_service):
+        """Test logs with invalid query run ID."""
+        with pytest.raises(InvalidQueryRunIDError):
+            query_runs_service.logs("")
+
+
+# ============================================================================
+# Cancel Operations Tests
+# ============================================================================
+
+
+class TestQueryRunsCancel:
+    """Test suite for query run cancel operations."""
+
+    def test_cancel_success(self, query_runs_service, mock_transport):
+        """Test successful query run cancellation."""
         mock_response = Mock()
-        mock_response.status_code = 202
-        client._transport.request = MagicMock(return_value=mock_response)
+        mock_transport.request.return_value = mock_response
 
-        client.query_runs.cancel("query-test123")
+        query_runs_service.cancel("qr-123abc456def")
 
-        client._transport.request.assert_called_once_with(
+        # Verify the request
+        mock_transport.request.assert_called_once_with(
             "POST",
-            "/api/v2/queries/query-test123/actions/cancel",
+            "/api/v2/queries/qr-123abc456def/actions/cancel",
             json_body=None,
         )
 
-    def test_cancel_query_run_with_options(self, client):
-        """Test canceling a query run with options."""
+    def test_cancel_with_comment(self, query_runs_service, mock_transport):
+        """Test cancellation with comment."""
         mock_response = Mock()
-        mock_response.status_code = 202
-        client._transport.request = MagicMock(return_value=mock_response)
+        mock_transport.request.return_value = mock_response
 
-        options = QueryRunCancelOptions(comment="Canceling for testing")
-        client.query_runs.cancel("query-test123", options)
+        options = QueryRunCancelOptions(comment="Canceling due to configuration error")
 
-        call_args = client._transport.request.call_args
-        assert call_args[0][1] == "/api/v2/queries/query-test123/actions/cancel"
+        query_runs_service.cancel("qr-123abc456def", options)
+
+        # Verify the request includes comment
+        call_args = mock_transport.request.call_args
+        assert call_args[0][0] == "POST"
+        assert call_args[0][1] == "/api/v2/queries/qr-123abc456def/actions/cancel"
         json_body = call_args[1]["json_body"]
-        assert json_body["data"]["attributes"]["comment"] == "Canceling for testing"
+        assert json_body["data"]["attributes"]["comment"] == "Canceling due to configuration error"
 
-    def test_force_cancel_query_run(self, client):
-        """Test force canceling a query run."""
+    def test_cancel_invalid_id(self, query_runs_service):
+        """Test cancel with invalid query run ID."""
+        with pytest.raises(InvalidQueryRunIDError):
+            query_runs_service.cancel("")
+
+
+# ============================================================================
+# Force Cancel Operations Tests
+# ============================================================================
+
+
+class TestQueryRunsForceCancel:
+    """Test suite for query run force cancel operations."""
+
+    def test_force_cancel_success(self, query_runs_service, mock_transport):
+        """Test successful force cancellation."""
         mock_response = Mock()
-        mock_response.status_code = 202
-        client._transport.request = MagicMock(return_value=mock_response)
+        mock_transport.request.return_value = mock_response
 
-        client.query_runs.force_cancel("query-test123")
+        query_runs_service.force_cancel("qr-123abc456def")
 
-        client._transport.request.assert_called_once_with(
+        # Verify the request
+        mock_transport.request.assert_called_once_with(
             "POST",
-            "/api/v2/queries/query-test123/actions/force-cancel",
+            "/api/v2/queries/qr-123abc456def/actions/force-cancel",
             json_body=None,
         )
 
-    def test_cancel_invalid_query_run_id(self, client):
-        """Test canceling with invalid query run ID."""
-        with pytest.raises(InvalidQueryRunIDError):
-            client.query_runs.cancel("")
+    def test_force_cancel_with_comment(self, query_runs_service, mock_transport):
+        """Test force cancellation with comment."""
+        mock_response = Mock()
+        mock_transport.request.return_value = mock_response
 
-    def test_force_cancel_invalid_query_run_id(self, client):
-        """Test force canceling with invalid query run ID."""
+        options = QueryRunForceCancelOptions(comment="Force canceling stuck query run")
+
+        query_runs_service.force_cancel("qr-123abc456def", options)
+
+        # Verify the request includes comment
+        call_args = mock_transport.request.call_args
+        assert call_args[0][0] == "POST"
+        assert call_args[0][1] == "/api/v2/queries/qr-123abc456def/actions/force-cancel"
+        json_body = call_args[1]["json_body"]
+        assert json_body["data"]["attributes"]["comment"] == "Force canceling stuck query run"
+
+    def test_force_cancel_invalid_id(self, query_runs_service):
+        """Test force cancel with invalid query run ID."""
         with pytest.raises(InvalidQueryRunIDError):
-            client.query_runs.force_cancel("")
+            query_runs_service.force_cancel("")
+
+
+# ============================================================================
+# Unit Tests - Model Validation
+# ============================================================================
+
+
+class TestQueryRunCreateOptions:
+    """Unit tests for QueryRunCreateOptions model."""
+
+    def test_create_with_required_fields(self):
+        """Test creating options with required fields only."""
+        options = QueryRunCreateOptions(
+            source=QueryRunSource.API,
+            workspace_id="ws-123",
+        )
+
+        assert options.source == QueryRunSource.API
+        assert options.workspace_id == "ws-123"
+        assert options.configuration_version_id is None
+        assert options.variables is None
+
+    def test_create_with_all_fields(self):
+        """Test creating options with all fields."""
+        variables = [
+            QueryRunVariable(key="var1", value="value1"),
+            QueryRunVariable(key="var2", value="value2"),
+        ]
+
+        options = QueryRunCreateOptions(
+            source=QueryRunSource.API,
+            workspace_id="ws-123",
+            configuration_version_id="cv-456",
+            variables=variables,
+        )
+
+        assert options.source == QueryRunSource.API
+        assert options.workspace_id == "ws-123"
+        assert options.configuration_version_id == "cv-456"
+        assert len(options.variables) == 2
+        assert options.variables[0].key == "var1"
+
+
+class TestQueryRunModel:
+    """Unit tests for QueryRun model."""
+
+    def test_status_enum_values(self):
+        """Test all status enum values."""
+        assert QueryRunStatus.PENDING.value == "pending"
+        assert QueryRunStatus.QUEUED.value == "queued"
+        assert QueryRunStatus.RUNNING.value == "running"
+        assert QueryRunStatus.FINISHED.value == "finished"
+        assert QueryRunStatus.ERRORED.value == "errored"
+        assert QueryRunStatus.CANCELED.value == "canceled"
+
+    def test_source_enum_value(self):
+        """Test source enum value."""
+        assert QueryRunSource.API.value == "tfe-api"
+
+
+# ============================================================================
+# Test Utilities
+# ============================================================================
+
+
+def test_query_run_variable():
+    """Test QueryRunVariable model."""
+    var = QueryRunVariable(key="test_key", value="test_value")
+
+    assert var.key == "test_key"
+    assert var.value == "test_value"
+
+
+def test_query_run_status_timestamps():
+    """Test QueryRunStatusTimestamps model."""
+    timestamps = QueryRunStatusTimestamps(
+        queued_at="2024-01-15T10:00:00Z",
+        running_at="2024-01-15T10:05:00Z",
+        errored_at="2024-01-15T10:10:00Z",
+    )
+
+    # Timestamps are datetime objects
+    assert timestamps.queued_at is not None
+    assert timestamps.running_at is not None
+    assert timestamps.errored_at is not None
+    assert timestamps.finished_at is None
+    assert timestamps.canceled_at is None

--- a/tests/units/test_query_run.py
+++ b/tests/units/test_query_run.py
@@ -1,22 +1,25 @@
 from datetime import datetime
 from unittest.mock import MagicMock, Mock
+import io
 
 import pytest
 
 from pytfe import TFEClient, TFEConfig
-from pytfe.errors import InvalidOrgError, InvalidQueryRunIDError
+from pytfe.errors import InvalidQueryRunIDError, InvalidWorkspaceIDError
 from pytfe.models.query_run import (
     QueryRun,
+    QueryRunActions,
     QueryRunCancelOptions,
     QueryRunCreateOptions,
     QueryRunForceCancelOptions,
+    QueryRunIncludeOpt,
     QueryRunList,
     QueryRunListOptions,
-    QueryRunLogs,
     QueryRunReadOptions,
-    QueryRunResults,
+    QueryRunSource,
     QueryRunStatus,
-    QueryRunType,
+    QueryRunStatusTimestamps,
+    QueryRunVariable,
 )
 
 
@@ -26,61 +29,57 @@ class TestQueryRunModels:
     def test_query_run_model_basic(self):
         """Test basic QueryRun model creation."""
         query_run = QueryRun(
-            id="qr-test123",
-            query="SELECT * FROM runs WHERE status = 'completed'",
-            query_type=QueryRunType.FILTER,
-            status=QueryRunStatus.COMPLETED,
+            id="query-test123",
+            source=QueryRunSource.API,
+            status=QueryRunStatus.PENDING,
             created_at=datetime.now(),
             updated_at=datetime.now(),
         )
-        assert query_run.id == "qr-test123"
-        assert query_run.query == "SELECT * FROM runs WHERE status = 'completed'"
-        assert query_run.query_type == QueryRunType.FILTER
-        assert query_run.status == QueryRunStatus.COMPLETED
+        assert query_run.id == "query-test123"
+        assert query_run.source == QueryRunSource.API
+        assert query_run.status == QueryRunStatus.PENDING
 
     def test_query_run_status_enum(self):
         """Test QueryRunStatus enum values."""
         assert QueryRunStatus.PENDING == "pending"
+        assert QueryRunStatus.QUEUED == "queued"
         assert QueryRunStatus.RUNNING == "running"
-        assert QueryRunStatus.COMPLETED == "completed"
+        assert QueryRunStatus.FINISHED == "finished"
         assert QueryRunStatus.ERRORED == "errored"
         assert QueryRunStatus.CANCELED == "canceled"
 
-    def test_query_run_type_enum(self):
-        """Test QueryRunType enum values."""
-        assert QueryRunType.FILTER == "filter"
-        assert QueryRunType.SEARCH == "search"
-        assert QueryRunType.ANALYTICS == "analytics"
+    def test_query_run_source_enum(self):
+        """Test QueryRunSource enum values."""
+        assert QueryRunSource.API == "tfe-api"
 
     def test_query_run_create_options(self):
         """Test QueryRunCreateOptions model."""
         options = QueryRunCreateOptions(
-            query="SELECT * FROM workspaces",
-            query_type=QueryRunType.SEARCH,
-            organization_name="test-org",
-            timeout_seconds=300,
-            max_results=1000,
+            source=QueryRunSource.API,
+            workspace_id="ws-test123",
         )
-        assert options.query == "SELECT * FROM workspaces"
-        assert options.query_type == QueryRunType.SEARCH
-        assert options.organization_name == "test-org"
-        assert options.timeout_seconds == 300
-        assert options.max_results == 1000
+        assert options.source == QueryRunSource.API
+        assert options.workspace_id == "ws-test123"
 
     def test_query_run_list_options(self):
         """Test QueryRunListOptions model."""
         options = QueryRunListOptions(
             page_number=2,
             page_size=50,
-            query_type=QueryRunType.FILTER,
-            status=QueryRunStatus.COMPLETED,
-            organization_name="test-org",
+            include=[QueryRunIncludeOpt.CREATED_BY],
         )
         assert options.page_number == 2
         assert options.page_size == 50
-        assert options.query_type == QueryRunType.FILTER
-        assert options.status == QueryRunStatus.COMPLETED
-        assert options.organization_name == "test-org"
+        assert QueryRunIncludeOpt.CREATED_BY in options.include
+
+    def test_query_run_actions(self):
+        """Test QueryRunActions model."""
+        actions = QueryRunActions(
+            is_cancelable=True,
+            is_force_cancelable=False,
+        )
+        assert actions.is_cancelable is True
+        assert actions.is_force_cancelable is False
 
 
 class TestQueryRunOperations:
@@ -93,24 +92,20 @@ class TestQueryRunOperations:
         return TFEClient(config)
 
     @pytest.fixture
-    def mock_response(self):
-        """Create a mock response."""
+    def mock_list_response(self):
+        """Create a mock list response."""
         mock = Mock()
         mock.json.return_value = {
             "data": [
                 {
-                    "id": "qr-test123",
-                    "type": "query-runs",
+                    "id": "query-test123",
+                    "type": "queries",
                     "attributes": {
-                        "query": "SELECT * FROM runs",
-                        "query-type": "filter",
-                        "status": "completed",
-                        "results-count": 42,
+                        "source": "tfe-api",
+                        "status": "finished",
                         "created-at": "2023-01-01T00:00:00Z",
                         "updated-at": "2023-01-01T00:05:00Z",
-                        "started-at": "2023-01-01T00:01:00Z",
-                        "finished-at": "2023-01-01T00:05:00Z",
-                        "organization-name": "test-org",
+                        "log-read-url": "https://archivist.terraform.io/v1/object/...",
                     },
                 }
             ],
@@ -126,123 +121,117 @@ class TestQueryRunOperations:
         }
         return mock
 
-    def test_list_query_runs(self, client, mock_response):
+    def test_list_query_runs(self, client, mock_list_response):
         """Test listing query runs."""
-        client._transport.request = MagicMock(return_value=mock_response)
+        client._transport.request = MagicMock(return_value=mock_list_response)
 
-        result = client.query_runs.list("test-org")
+        result = client.query_runs.list("ws-test123")
 
         assert isinstance(result, QueryRunList)
         assert len(result.items) == 1
-        assert result.items[0].id == "qr-test123"
-        assert result.items[0].query == "SELECT * FROM runs"
+        assert result.items[0].id == "query-test123"
+        assert result.items[0].source == QueryRunSource.API
         assert result.current_page == 1
         assert result.total_count == 1
 
         client._transport.request.assert_called_once_with(
-            "GET", "/api/v2/organizations/test-org/query-runs", params=None
+            "GET", "/api/v2/workspaces/ws-test123/queries", params=None
         )
 
-    def test_list_query_runs_with_options(self, client, mock_response):
+    def test_list_query_runs_with_options(self, client, mock_list_response):
         """Test listing query runs with options."""
-        client._transport.request = MagicMock(return_value=mock_response)
+        client._transport.request = MagicMock(return_value=mock_list_response)
 
         options = QueryRunListOptions(
             page_number=2,
             page_size=25,
-            query_type=QueryRunType.FILTER,
-            status=QueryRunStatus.COMPLETED,
+            include=[QueryRunIncludeOpt.CREATED_BY],
         )
-        result = client.query_runs.list("test-org", options)
+        result = client.query_runs.list("ws-test123", options)
 
         assert isinstance(result, QueryRunList)
         client._transport.request.assert_called_once_with(
             "GET",
-            "/api/v2/organizations/test-org/query-runs",
+            "/api/v2/workspaces/ws-test123/queries",
             params={
                 "page[number]": 2,
                 "page[size]": 25,
-                "filter[query-type]": "filter",
-                "filter[status]": "completed",
+                "include": [QueryRunIncludeOpt.CREATED_BY],
             },
         )
+
+    def test_list_invalid_workspace_id(self, client):
+        """Test listing query runs with invalid workspace ID."""
+        with pytest.raises(InvalidWorkspaceIDError):
+            client.query_runs.list("")
 
     def test_create_query_run(self, client):
         """Test creating a query run."""
         mock_response = Mock()
         mock_response.json.return_value = {
             "data": {
-                "id": "qr-new123",
-                "type": "query-runs",
+                "id": "query-new123",
+                "type": "queries",
                 "attributes": {
-                    "query": "SELECT * FROM workspaces",
-                    "query-type": "search",
+                    "source": "tfe-api",
                     "status": "pending",
                     "created-at": "2023-01-01T00:00:00Z",
                     "updated-at": "2023-01-01T00:00:00Z",
-                    "organization-name": "test-org",
                 },
             }
         }
         client._transport.request = MagicMock(return_value=mock_response)
 
         options = QueryRunCreateOptions(
-            query="SELECT * FROM workspaces",
-            query_type=QueryRunType.SEARCH,
-            organization_name="test-org",
-            timeout_seconds=300,
+            source=QueryRunSource.API,
+            workspace_id="ws-test123",
         )
-        result = client.query_runs.create("test-org", options)
+        result = client.query_runs.create(options)
 
         assert isinstance(result, QueryRun)
-        assert result.id == "qr-new123"
-        assert result.query == "SELECT * FROM workspaces"
+        assert result.id == "query-new123"
+        assert result.source == QueryRunSource.API
         assert result.status == QueryRunStatus.PENDING
 
-        client._transport.request.assert_called_once_with(
-            "POST",
-            "/api/v2/organizations/test-org/query-runs",
-            json_body={
-                "data": {
-                    "attributes": {
-                        "query": "SELECT * FROM workspaces",
-                        "query-type": "search",
-                        "organization-name": "test-org",
-                        "timeout-seconds": 300,
-                    },
-                    "type": "query-runs",
-                }
-            },
-        )
+        # Verify the call was made with correct structure
+        call_args = client._transport.request.call_args
+        assert call_args[0][0] == "POST"
+        assert call_args[0][1] == "/api/v2/queries"
+        json_body = call_args[1]["json_body"]
+        assert json_body["data"]["type"] == "queries"
+        assert "relationships" in json_body["data"]
+        assert json_body["data"]["relationships"]["workspace"]["data"]["id"] == "ws-test123"
 
     def test_read_query_run(self, client):
         """Test reading a query run."""
         mock_response = Mock()
         mock_response.json.return_value = {
             "data": {
-                "id": "qr-test123",
-                "type": "query-runs",
+                "id": "query-test123",
+                "type": "queries",
                 "attributes": {
-                    "query": "SELECT * FROM runs",
-                    "query-type": "filter",
-                    "status": "completed",
-                    "results-count": 42,
+                    "source": "tfe-api",
+                    "status": "finished",
                     "created-at": "2023-01-01T00:00:00Z",
                     "updated-at": "2023-01-01T00:05:00Z",
+                    "log-read-url": "https://archivist.terraform.io/v1/object/...",
+                    "actions": {
+                        "is-cancelable": False,
+                        "is-force-cancelable": False,
+                    },
                 },
             }
         }
         client._transport.request = MagicMock(return_value=mock_response)
 
-        result = client.query_runs.read("qr-test123")
+        result = client.query_runs.read("query-test123")
 
         assert isinstance(result, QueryRun)
-        assert result.id == "qr-test123"
-        assert result.status == QueryRunStatus.COMPLETED
-        assert result.results_count == 42
+        assert result.id == "query-test123"
+        assert result.status == QueryRunStatus.FINISHED
 
         client._transport.request.assert_called_once_with(
-            "GET", "/api/v2/query-runs/qr-test123"
+            "GET", "/api/v2/queries/query-test123"
         )
 
     def test_read_query_run_with_options(self, client):
@@ -250,12 +239,11 @@ class TestQueryRunOperations:
         mock_response = Mock()
         mock_response.json.return_value = {
             "data": {
-                "id": "qr-test123",
-                "type": "query-runs",
+                "id": "query-test123",
+                "type": "queries",
                 "attributes": {
-                    "query": "SELECT * FROM runs",
-                    "query-type": "filter",
-                    "status": "completed",
+                    "source": "tfe-api",
+                    "status": "finished",
                     "created-at": "2023-01-01T00:00:00Z",
                     "updated-at": "2023-01-01T00:05:00Z",
                 },
@@ -263,302 +251,127 @@ class TestQueryRunOperations:
         }
         client._transport.request = MagicMock(return_value=mock_response)
 
-        options = QueryRunReadOptions(include_results=True, include_logs=True)
-        result = client.query_runs.read_with_options("qr-test123", options)
+        options = QueryRunReadOptions(
+            include=[QueryRunIncludeOpt.CREATED_BY, QueryRunIncludeOpt.CONFIGURATION_VERSION]
+        )
+        result = client.query_runs.read_with_options("query-test123", options)
 
         assert isinstance(result, QueryRun)
-        assert result.id == "qr-test123"
+        assert result.id == "query-test123"
 
         client._transport.request.assert_called_once_with(
             "GET",
-            "/api/v2/query-runs/qr-test123",
-            params={"include[results]": True, "include[logs]": True},
+            "/api/v2/queries/query-test123",
+            params={"include": [QueryRunIncludeOpt.CREATED_BY, QueryRunIncludeOpt.CONFIGURATION_VERSION]},
         )
+
+    def test_read_invalid_query_run_id(self, client):
+        """Test reading with invalid query run ID."""
+        with pytest.raises(InvalidQueryRunIDError):
+            client.query_runs.read("")
 
     def test_query_run_logs(self, client):
         """Test retrieving query run logs."""
-        mock_response = Mock()
-        mock_response.headers = {"content-type": "text/plain"}
-        mock_response.text = (
-            "Starting query execution...\nQuery completed successfully."
-        )
-        client._transport.request = MagicMock(return_value=mock_response)
-
-        result = client.query_runs.logs("qr-test123")
-
-        assert isinstance(result, QueryRunLogs)
-        assert result.query_run_id == "qr-test123"
-        assert "Starting query execution" in result.logs
-        assert result.log_level == "info"
-
-        client._transport.request.assert_called_once_with(
-            "GET", "/api/v2/query-runs/qr-test123/logs"
-        )
-
-    def test_query_run_results(self, client):
-        """Test retrieving query run results."""
-        mock_response = Mock()
-        mock_response.json.return_value = {
+        # Mock the read call first
+        mock_read_response = Mock()
+        mock_read_response.json.return_value = {
             "data": {
-                "results": [
-                    {"id": "run-1", "status": "completed"},
-                    {"id": "run-2", "status": "pending"},
-                ],
-                "total_count": 2,
-                "truncated": False,
+                "id": "query-test123",
+                "type": "queries",
+                "attributes": {
+                    "source": "tfe-api",
+                    "status": "finished",
+                    "created-at": "2023-01-01T00:00:00Z",
+                    "updated-at": "2023-01-01T00:05:00Z",
+                    "log-read-url": "https://archivist.terraform.io/v1/object/dmF1bHQ6djE6L...",
+                },
             }
         }
-        client._transport.request = MagicMock(return_value=mock_response)
+        
+        # Mock the logs fetch
+        mock_logs_response = Mock()
+        mock_logs_response.content = b"Starting query execution...\nQuery completed successfully."
+        
+        client._transport.request = MagicMock(side_effect=[mock_read_response, mock_logs_response])
 
-        result = client.query_runs.results("qr-test123")
+        result = client.query_runs.logs("query-test123")
 
-        assert isinstance(result, QueryRunResults)
-        assert result.query_run_id == "qr-test123"
-        assert len(result.results) == 2
-        assert result.total_count == 2
-        assert not result.truncated
+        assert isinstance(result, io.IOBase)
+        log_content = result.read()
+        assert b"Starting query execution" in log_content
 
-        client._transport.request.assert_called_once_with(
-            "GET", "/api/v2/query-runs/qr-test123/results"
-        )
+        # Verify calls
+        assert client._transport.request.call_count == 2
+
+    def test_query_run_logs_no_url(self, client):
+        """Test retrieving logs when no log URL is available."""
+        mock_read_response = Mock()
+        mock_read_response.json.return_value = {
+            "data": {
+                "id": "query-test123",
+                "type": "queries",
+                "attributes": {
+                    "source": "tfe-api",
+                    "status": "pending",
+                    "created-at": "2023-01-01T00:00:00Z",
+                    "updated-at": "2023-01-01T00:00:00Z",
+                },
+            }
+        }
+        
+        client._transport.request = MagicMock(return_value=mock_read_response)
+
+        with pytest.raises(ValueError, match="does not have a log URL"):
+            client.query_runs.logs("query-test123")
 
     def test_cancel_query_run(self, client):
         """Test canceling a query run."""
         mock_response = Mock()
-        mock_response.json.return_value = {
-            "data": {
-                "id": "qr-test123",
-                "type": "query-runs",
-                "attributes": {
-                    "query": "SELECT * FROM runs",
-                    "query-type": "filter",
-                    "status": "canceled",
-                    "created-at": "2023-01-01T00:00:00Z",
-                    "updated-at": "2023-01-01T00:02:00Z",
-                },
-            }
-        }
+        mock_response.status_code = 202
         client._transport.request = MagicMock(return_value=mock_response)
 
-        options = QueryRunCancelOptions(reason="User requested cancellation")
-        result = client.query_runs.cancel("qr-test123", options)
-
-        assert isinstance(result, QueryRun)
-        assert result.id == "qr-test123"
-        assert result.status == QueryRunStatus.CANCELED
+        client.query_runs.cancel("query-test123")
 
         client._transport.request.assert_called_once_with(
             "POST",
-            "/api/v2/query-runs/qr-test123/actions/cancel",
-            json_body={
-                "data": {
-                    "attributes": {"reason": "User requested cancellation"},
-                    "type": "query-runs",
-                }
-            },
+            "/api/v2/queries/query-test123/actions/cancel",
+            json_body=None,
         )
+
+    def test_cancel_query_run_with_options(self, client):
+        """Test canceling a query run with options."""
+        mock_response = Mock()
+        mock_response.status_code = 202
+        client._transport.request = MagicMock(return_value=mock_response)
+
+        options = QueryRunCancelOptions(comment="Canceling for testing")
+        client.query_runs.cancel("query-test123", options)
+
+        call_args = client._transport.request.call_args
+        assert call_args[0][1] == "/api/v2/queries/query-test123/actions/cancel"
+        json_body = call_args[1]["json_body"]
+        assert json_body["data"]["attributes"]["comment"] == "Canceling for testing"
 
     def test_force_cancel_query_run(self, client):
         """Test force canceling a query run."""
         mock_response = Mock()
-        mock_response.json.return_value = {
-            "data": {
-                "id": "qr-test123",
-                "type": "query-runs",
-                "attributes": {
-                    "query": "SELECT * FROM runs",
-                    "query-type": "filter",
-                    "status": "canceled",
-                    "created-at": "2023-01-01T00:00:00Z",
-                    "updated-at": "2023-01-01T00:02:00Z",
-                },
-            }
-        }
+        mock_response.status_code = 202
         client._transport.request = MagicMock(return_value=mock_response)
 
-        options = QueryRunForceCancelOptions(reason="Force cancel due to timeout")
-        result = client.query_runs.force_cancel("qr-test123", options)
-
-        assert isinstance(result, QueryRun)
-        assert result.id == "qr-test123"
-        assert result.status == QueryRunStatus.CANCELED
+        client.query_runs.force_cancel("query-test123")
 
         client._transport.request.assert_called_once_with(
             "POST",
-            "/api/v2/query-runs/qr-test123/actions/force-cancel",
-            json_body={
-                "data": {
-                    "attributes": {"reason": "Force cancel due to timeout"},
-                    "type": "query-runs",
-                }
-            },
+            "/api/v2/queries/query-test123/actions/force-cancel",
+            json_body=None,
         )
 
-
-class TestQueryRunErrorHandling:
-    """Test query run error handling."""
-
-    @pytest.fixture
-    def client(self):
-        """Create a test client."""
-        config = TFEConfig(address="https://test.terraform.io", token="test-token")
-        return TFEClient(config)
-
-    def test_invalid_organization_error(self, client):
-        """Test invalid organization error."""
-        with pytest.raises(InvalidOrgError):
-            client.query_runs.list("")
-
-        with pytest.raises(InvalidOrgError):
-            client.query_runs.list(None)
-
-    def test_invalid_query_run_id_error(self, client):
-        """Test invalid query run ID error."""
-        with pytest.raises(InvalidQueryRunIDError):
-            client.query_runs.read("")
-
-        with pytest.raises(InvalidQueryRunIDError):
-            client.query_runs.read(None)
-
-        with pytest.raises(InvalidQueryRunIDError):
-            client.query_runs.logs("")
-
-        with pytest.raises(InvalidQueryRunIDError):
-            client.query_runs.results("")
-
+    def test_cancel_invalid_query_run_id(self, client):
+        """Test canceling with invalid query run ID."""
         with pytest.raises(InvalidQueryRunIDError):
             client.query_runs.cancel("")
 
+    def test_force_cancel_invalid_query_run_id(self, client):
+        """Test force canceling with invalid query run ID."""
         with pytest.raises(InvalidQueryRunIDError):
             client.query_runs.force_cancel("")
-
-    def test_create_query_run_validation_errors(self, client):
-        """Test create query run validation errors."""
-        with pytest.raises(InvalidOrgError):
-            options = QueryRunCreateOptions(
-                query="SELECT * FROM runs", query_type=QueryRunType.FILTER
-            )
-            client.query_runs.create("", options)
-
-
-class TestQueryRunIntegration:
-    """Test query run integration scenarios."""
-
-    @pytest.fixture
-    def client(self):
-        """Create a test client with mocked transport."""
-        from unittest.mock import MagicMock, patch
-
-        # Mock the HTTPTransport to prevent any network calls during initialization
-        with patch("pytfe.client.HTTPTransport") as mock_transport_class:
-            mock_transport_instance = MagicMock()
-            mock_transport_class.return_value = mock_transport_instance
-
-            config = TFEConfig(address="https://test.terraform.io", token="test-token")
-            client = TFEClient(config)
-            return client
-
-    def test_full_query_run_workflow(self, client):
-        """Test a complete query run workflow simulation."""
-        # Use the already mocked transport from the fixture
-        mock_transport = client._transport
-
-        # 1. Create query run
-        create_response = Mock()
-        create_response.json.return_value = {
-            "data": {
-                "id": "qr-workflow123",
-                "type": "query-runs",
-                "attributes": {
-                    "query": "SELECT * FROM runs WHERE status = 'completed'",
-                    "query-type": "filter",
-                    "status": "pending",
-                    "created-at": "2023-01-01T00:00:00Z",
-                    "updated-at": "2023-01-01T00:00:00Z",
-                    "organization-name": "test-org",
-                },
-            }
-        }
-
-        # 2. Read query run (running state)
-        read_response = Mock()
-        read_response.json.return_value = {
-            "data": {
-                "id": "qr-workflow123",
-                "type": "query-runs",
-                "attributes": {
-                    "query": "SELECT * FROM runs WHERE status = 'completed'",
-                    "query-type": "filter",
-                    "status": "running",
-                    "created-at": "2023-01-01T00:00:00Z",
-                    "updated-at": "2023-01-01T00:01:00Z",
-                    "started-at": "2023-01-01T00:01:00Z",
-                },
-            }
-        }
-
-        # 3. Read query run (completed state)
-        completed_response = Mock()
-        completed_response.json.return_value = {
-            "data": {
-                "id": "qr-workflow123",
-                "type": "query-runs",
-                "attributes": {
-                    "query": "SELECT * FROM runs WHERE status = 'completed'",
-                    "query-type": "filter",
-                    "status": "completed",
-                    "results-count": 15,
-                    "created-at": "2023-01-01T00:00:00Z",
-                    "updated-at": "2023-01-01T00:05:00Z",
-                    "started-at": "2023-01-01T00:01:00Z",
-                    "finished-at": "2023-01-01T00:05:00Z",
-                },
-            }
-        }
-
-        # 4. Get results
-        results_response = Mock()
-        results_response.json.return_value = {
-            "data": {
-                "results": [
-                    {"id": f"run-{i}", "status": "completed"} for i in range(15)
-                ],
-                "total_count": 15,
-                "truncated": False,
-            }
-        }
-
-        mock_transport.request.side_effect = [
-            create_response,
-            read_response,
-            completed_response,
-            results_response,
-        ]
-
-        # Execute workflow
-        options = QueryRunCreateOptions(
-            query="SELECT * FROM runs WHERE status = 'completed'",
-            query_type=QueryRunType.FILTER,
-            organization_name="test-org",
-        )
-
-        # 1. Create
-        query_run = client.query_runs.create("test-org", options)
-        assert query_run.status == QueryRunStatus.PENDING
-
-        # 2. Check status (running)
-        query_run = client.query_runs.read(query_run.id)
-        assert query_run.status == QueryRunStatus.RUNNING
-
-        # 3. Check status (completed)
-        query_run = client.query_runs.read(query_run.id)
-        assert query_run.status == QueryRunStatus.COMPLETED
-        assert query_run.results_count == 15
-
-        # 4. Get results
-        results = client.query_runs.results(query_run.id)
-        assert len(results.results) == 15
-        assert not results.truncated
-
-        # Verify all calls were made
-        assert mock_transport.request.call_count == 4


### PR DESCRIPTION
Following functions are created:
    1. list(workspace_id, options) - Lists all query runs for a workspace with automatic pagination
    2. create(options) - Creates a new query run with workspace and optional configuration version
    3. read(query_run_id) - Retrieves query run details by ID
    4. read_with_options(query_run_id, options) - Reads query run with relationship includes (created_by, configuration_version)
    5. logs(query_run_id) - Retrieves query run execution logs as an IO stream
    6. cancel(query_run_id, options) - Gracefully cancels a running query run with optional comment
    7. force_cancel(query_run_id, options) - Force cancels a stuck query run with optional comment

**Note: The functions were pointing to wrong endpoints. That is also fixed as part of this PR**

### Output from Manual testing
```
================================================================================
QUERY RUN FUNCTION TESTS
================================================================================
Testing all Query Run API operations

NOTE: Query Runs require Terraform 1.10+ with 'terraform query' command.
      Most query runs will error since this feature is not yet available.
================================================================================
=== Test 1: List Query Runs ===
Found 34 query runs in workspace 'query-test'
  1. qry-ibSqakxbRdakQMjs
     Status: QueryRunStatus.ERRORED
     Created: 2025-12-21 14:00:31.981000+00:00

  2. qry-ZhaCWyppLrya3rmr
     Status: QueryRunStatus.CANCELED
     Created: 2025-12-21 14:00:24.924000+00:00

  3. qry-xYywfhd3Vjr17nWi
     Status: QueryRunStatus.ERRORED
     Created: 2025-12-21 14:00:16.967000+00:00

  4. qry-ZdGNVnx26D83FSTM
     Status: QueryRunStatus.ERRORED
     Created: 2025-12-21 13:33:36.802000+00:00

  5. qry-kk6VXT1FXzSWYPRv
     Status: QueryRunStatus.CANCELED
     Created: 2025-12-21 13:33:30.209000+00:00

Retrieved 34 query runs (page_size=5)

=== Test 2: Create Query Run ===
Using configuration version: cv-6rVj5eRunDdUMmU7
Created query run: qry-tk8NwVHzU2xZ4GDp
  Status: QueryRunStatus.QUEUED
  Source: tfe-api
  Created: 2025-12-21 14:03:40.545000+00:00

=== Test 3: Read Query Run ===
Read query run: qry-ibSqakxbRdakQMjs
  Status: QueryRunStatus.ERRORED
  Source: tfe-api
  Created: 2025-12-21 14:00:31.981000+00:00
  Status Timestamps:
    Queued: 2025-12-21 14:00:31.996000+00:00
    Running: 2025-12-21 14:00:33.637000+00:00
    Errored: 2025-12-21 14:00:36.708000+00:00

=== Test 4: Get Query Run Logs ===
Error: HTTP 400
  Note: Logs may not be available if the query run hasn't started yet

=== Test 5: Cancel Query Run ===
Creating a new query run to cancel...

=== Test 2: Create Query Run ===
Using configuration version: cv-6rVj5eRunDdUMmU7
Created query run: qry-TKaKUPfMQuTDrFzb
  Status: QueryRunStatus.QUEUED
  Source: tfe-api
  Created: 2025-12-21 14:03:49.719000+00:00
Cancel requested for query run: qry-TKaKUPfMQuTDrFzb
  Status after cancel: QueryRunStatus.CANCELED

=== Test 6: Force Cancel Query Run ===
Creating a new query run to force cancel...

=== Test 2: Create Query Run ===
Using configuration version: cv-6rVj5eRunDdUMmU7
Created query run: qry-e2XdPXaJW6QfhRsm
  Status: QueryRunStatus.QUEUED
  Source: tfe-api
  Created: 2025-12-21 14:03:57.003000+00:00
Error: Not found. This resource does not exist or may need to be authenticated
  Note: Query run may not be in a force-cancelable state
```

### TestCase Run:
<img width="755" height="411" alt="Screenshot 2025-12-21 at 7 38 55 PM" src="https://github.com/user-attachments/assets/76030643-f354-4433-87af-c11e4fedb0e5" />
