### PR TITLE
fix: Allow RunListOptions to be populated by name

### DIFF
--- a/src/pytfe/models/run.py
+++ b/src/pytfe/models/run.py
@@ -216,6 +216,10 @@ class RunList(BaseModel):
 
 
 class RunListOptions(BaseModel):
+    """RunListOption represent the query options for listing runs."""
+
+    model_config = ConfigDict(populate_by_name=True, validate_by_name=True)
+
     page_number: int | None = Field(default=1, alias="page[number]")
     page_size: int | None = Field(default=20, alias="page[size]")
 


### PR DESCRIPTION
We should be able to declare a RunListOption as this RunListOptions(status=RunStatus.Run_Planned)
and have the status parameter set in the resulting http query

## Description

`RunListOptions` model doesn't accept field name, only alias while any other models allow it.

## Testing plan

~~~
    rlo = RunListOptions(
        status=RunStatus.Run_Planned,
    )
    runs = client.runs.list(workspace_id=workspace_id, options=rlo)
~~~
This code doesn't filter run by status

## External links

None

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

## Rollback Plan

None

## Changes to Security Controls

None

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).
