### PR TITLE
fix(config-version): Updated upload method and ConfigurationSource Enum in the configuration version 

### DIFF
--- a/examples/configuration_version.py
+++ b/examples/configuration_version.py
@@ -277,29 +277,8 @@ def main():
                     print(f"       - {filename} ({size} bytes)")
 
                 try:
-                    # Create tar.gz archive manually since go-slug isn't available
-                    print("Creating tar.gz archive manually...")
-
-                    import tarfile
-
-                    # Create tar.gz archive in memory
-                    archive_buffer = io.BytesIO()
-                    with tarfile.open(fileobj=archive_buffer, mode="w:gz") as tar:
-                        # Add all files from the temp directory
-                        for filename in files:
-                            filepath = os.path.join(temp_dir, filename)
-                            tar.add(filepath, arcname=filename)
-
-                    archive_buffer.seek(0)
-                    archive_bytes = archive_buffer.getvalue()
-                    print(f"Created archive: {len(archive_bytes)} bytes")
-
-                    # Use the SDK's upload_tar_gzip method instead of direct HTTP calls
-                    print("Uploading archive using SDK method...")
-                    archive_buffer.seek(0)  # Reset buffer position
-                    client.configuration_versions.upload_tar_gzip(
-                        new_cv.upload_url, archive_buffer
-                    )
+                    print("Uploading Terraform configuration...")
+                    client.configuration_versions.upload(new_cv.upload_url, temp_dir)
                     print("Terraform configuration uploaded successfully!")
 
                     # Wait and check status
@@ -408,8 +387,6 @@ def main():
     # =====================================================
     # TEST 4: UPLOAD CONFIGURATION VERSION
     # =====================================================
-    # Test 4: Upload function (requires go-slug)
-    # =====================================================
     print("\n4. Testing upload() function:")
     try:
         # Create a fresh configuration version specifically for upload testing
@@ -441,33 +418,19 @@ def main():
                 print(f"\n Uploading configuration to CV: {fresh_cv.id}")
                 print(f"Upload URL: {upload_url[:60]}...")
 
-                try:
-                    client.configuration_versions.upload(upload_url, temp_dir)
-                    print("Configuration uploaded successfully!")
+                client.configuration_versions.upload(upload_url, temp_dir)
+                print("Configuration uploaded successfully!")
 
-                    # Check status after upload
-                    print("\n Checking status after upload:")
-                    time.sleep(3)  # Give TFE time to process
-                    updated_cv = client.configuration_versions.read(fresh_cv.id)
-                    print(f"Status after upload: {updated_cv.status}")
+                # Check status after upload
+                print("\n Checking status after upload:")
+                time.sleep(3)  # Give TFE time to process
+                updated_cv = client.configuration_versions.read(fresh_cv.id)
+                print(f"Status after upload: {updated_cv.status}")
 
-                    if updated_cv.status.value != "pending":
-                        print("Status changed (upload processed)")
-                    else:
-                        print("Status still pending (may need more time)")
-
-                except ImportError as e:
-                    if "go-slug" in str(e):
-                        print("go-slug package not available")
-                        print("Install with: pip install go-slug")
-                        print(
-                            "Upload function exists but requires go-slug for packaging"
-                        )
-                        print(
-                            "Function correctly raises ImportError when go-slug unavailable"
-                        )
-                    else:
-                        raise
+                if updated_cv.status.value != "pending":
+                    print("Status changed (upload processed)")
+                else:
+                    print("Status still pending (may need more time)")
 
     except Exception as e:
         print(f"Error: {e}")
@@ -868,7 +831,7 @@ def main():
         "TEST 2:  create() - Create new configuration versions with different options"
     )
     print("TEST 3:  read() - Read configuration version details and validate fields")
-    print("TEST 4:  upload() - Upload Terraform configurations (requires go-slug)")
+    print("TEST 4:  upload() - Upload Terraform configurations (stdlib tarfile)")
     print("TEST 5:  download() - Download configuration version archives")
     print("TEST 6:  archive() - Archive configuration versions")
     print("TEST 7:  read_with_options() - Read with include options")

--- a/src/pytfe/models/configuration_version.py
+++ b/src/pytfe/models/configuration_version.py
@@ -25,6 +25,7 @@ class ConfigurationSource(str, Enum):
     GITLAB = "gitlab"
     ADO = "ado"
     TERRAFORM = "terraform"
+    TERRAFORM_CLOUD = "terraform+cloud"
 
 
 class ConfigVerIncludeOpt(str, Enum):

--- a/src/pytfe/utils.py
+++ b/src/pytfe/utils.py
@@ -366,7 +366,9 @@ def pack_contents(path: str) -> io.BytesIO:
         ValueError: If path is invalid
     """
     if not path or not os.path.isdir(path):
-        raise ValueError(f"Failed to pack directory {path}: path must be an existing directory")
+        raise ValueError(
+            f"Failed to pack directory {path}: path must be an existing directory"
+        )
 
     body = io.BytesIO()
 
@@ -375,7 +377,9 @@ def pack_contents(path: str) -> io.BytesIO:
             rel_root = os.path.relpath(root, path)
             for filename in files:
                 full_path = os.path.join(root, filename)
-                arcname = filename if rel_root == "." else os.path.join(rel_root, filename)
+                arcname = (
+                    filename if rel_root == "." else os.path.join(rel_root, filename)
+                )
                 tar.add(full_path, arcname=arcname, recursive=False)
 
     body.seek(0)

--- a/src/pytfe/utils.py
+++ b/src/pytfe/utils.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import io
+import os
 import re
+import tarfile
 import time
 from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
@@ -14,11 +16,6 @@ if TYPE_CHECKING:
     )
 
 from urllib.parse import urlparse
-
-try:
-    import slug  # type: ignore[import-not-found]
-except ImportError:
-    slug = None
 
 from .errors import (
     InvalidNameError,
@@ -366,26 +363,21 @@ def pack_contents(path: str) -> io.BytesIO:
         BytesIO buffer containing the tar.gz archive
 
     Raises:
-        ImportError: If go-slug is not available
         ValueError: If path is invalid
     """
-    if slug is None:
-        raise ImportError(
-            "go-slug package is required for packing configuration files. "
-            "Install it with: pip install go-slug"
-        )
+    if not path or not os.path.isdir(path):
+        raise ValueError(f"Failed to pack directory {path}: path must be an existing directory")
 
     body = io.BytesIO()
 
-    # Use go-slug to pack the configuration directory
-    # This handles .terraformignore and other Terraform-specific behaviors
-    packer = slug.Packer()
-    _, err = packer.pack(path, body)
+    with tarfile.open(fileobj=body, mode="w:gz") as tar:
+        for root, _, files in os.walk(path):
+            rel_root = os.path.relpath(root, path)
+            for filename in files:
+                full_path = os.path.join(root, filename)
+                arcname = filename if rel_root == "." else os.path.join(rel_root, filename)
+                tar.add(full_path, arcname=arcname, recursive=False)
 
-    if err:
-        raise ValueError(f"Failed to pack directory {path}: {err}")
-
-    # Reset buffer position to beginning for reading
     body.seek(0)
     return body
 

--- a/tests/units/test_configuration_version.py
+++ b/tests/units/test_configuration_version.py
@@ -17,7 +17,7 @@ This test suite covers all 12 configuration version methods:
 """
 
 import io
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 
@@ -343,9 +343,7 @@ class TestConfigurationVersionsReadWithOptions:
 class TestConfigurationVersionsUpload:
     """Test configuration versions upload functionality."""
 
-    def test_upload_packs_with_tar(
-        self, configuration_versions_service, tmp_path
-    ):
+    def test_upload_packs_with_tar(self, configuration_versions_service, tmp_path):
         """Test upload works by packing a directory to tar.gz with stdlib."""
         upload_url = "https://example.com/upload"
         directory_path = tmp_path

--- a/tests/units/test_configuration_version.py
+++ b/tests/units/test_configuration_version.py
@@ -343,35 +343,35 @@ class TestConfigurationVersionsReadWithOptions:
 class TestConfigurationVersionsUpload:
     """Test configuration versions upload functionality."""
 
-    def test_upload_missing_slug(self, configuration_versions_service):
-        """Test upload when go-slug is not available."""
+    def test_upload_packs_with_tar(
+        self, configuration_versions_service, tmp_path
+    ):
+        """Test upload works by packing a directory to tar.gz with stdlib."""
         upload_url = "https://example.com/upload"
-        directory_path = "/tmp/test"
+        directory_path = tmp_path
+        (directory_path / "main.tf").write_text('resource "null_resource" "test" {}')
 
-        with patch("src.pytfe.utils.slug", None):
-            with pytest.raises(ImportError, match="go-slug package is required"):
-                configuration_versions_service.upload(upload_url, directory_path)
+        mock_response = Mock()
+        mock_response.status_code = 200
+        configuration_versions_service.t._sync.put.return_value = mock_response
 
-    @patch("src.pytfe.utils.slug")
-    def test_upload_success(self, mock_slug, configuration_versions_service):
+        configuration_versions_service.upload(upload_url, str(directory_path))
+
+        configuration_versions_service.t._sync.put.assert_called_once()
+
+    def test_upload_success(self, configuration_versions_service, tmp_path):
         """Test successful upload."""
-        # Mock slug.pack
-        mock_packer = Mock()
-        mock_packer.pack.return_value = (None, None)  # (size, error)
-        mock_slug.Packer.return_value = mock_packer
-
         upload_url = "https://example.com/upload"
-        directory_path = "/tmp/test"
+        directory_path = tmp_path
+        (directory_path / "main.tf").write_text('resource "null_resource" "test" {}')
 
         # Mock transport's underlying httpx client instead of direct httpx
         mock_response = Mock()
         mock_response.status_code = 200
         configuration_versions_service.t._sync.put.return_value = mock_response
 
-        configuration_versions_service.upload(upload_url, directory_path)
-
-        # Verify slug.pack was called
-        mock_packer.pack.assert_called_once()
+        configuration_versions_service.upload(upload_url, str(directory_path))
+        configuration_versions_service.t._sync.put.assert_called_once()
 
 
 class TestConfigurationVersionsUploadTarGzip:


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/python-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->

- Removed the go-slug third-party package from the configuration version upload path, replacing it with Python's stdlib tarfile. 
- Fixed a missing ConfigurationSource enum value that caused a Pydantic ValidationError when listing CVs with source "terraform+cloud".

### Changes

**utils.py**

- Removed the try/except import guard for slug
- pack_contents(path) now uses tarfile with os.walk to build the archive into an io.BytesIO buffer
- Raises ValueError (instead of ImportError) when the path is not a valid existing directory

**models/configuration_version.py**

- Added TERRAFORM_CLOUD = "terraform+cloud" to ConfigurationSource
- Prevents a Pydantic ValidationError when deserialising configuration versions whose source is "terraform+cloud"

**Examples and Unit tests**
- Updated the examples and unit tests of configuration version

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

- [Issue-88](https://github.com/hashicorp/python-tfe/issues/88)
- [Issue-93](https://github.com/hashicorp/python-tfe/issues/93)
- [JIRA](https://hashicorp.atlassian.net/browse/TF-35307)
- [JIRA](https://hashicorp.atlassian.net/browse/TF-35308)

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->

## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).
