### PR TITLE
Bugfix/pagination

### DIFF
--- a/src/pytfe/resources/_base.py
+++ b/src/pytfe/resources/_base.py
@@ -16,7 +16,7 @@ class _Service:
         page = 1
         while True:
             p = dict(params or {})
-            p.setdefault("page[number]", page)
+            p["page[number]"] = page
             p.setdefault("page[size]", 100)
             r = self.t.request("GET", path, params=p)
 

--- a/tests/units/test_agent_pools.py
+++ b/tests/units/test_agent_pools.py
@@ -139,7 +139,6 @@ class TestAgentPoolOperations:
         mock_transport.request.return_value.json.return_value = mock_response
 
         options = AgentPoolListOptions(
-            page_number=2,
             page_size=10,
             allowed_workspace_policy=AgentPoolAllowedWorkspacePolicy.ALL_WORKSPACES,
         )
@@ -150,7 +149,7 @@ class TestAgentPoolOperations:
         mock_transport.request.assert_called_once()
         call_args = mock_transport.request.call_args
         params = call_args[1]["params"]
-        assert params["page[number]"] == 2
+        assert params["page[number]"] == 1
         assert params["page[size]"] == 10
         assert params["filter[allowed_workspace_policy]"] == "all-workspaces"
 

--- a/tests/units/test_configuration_version.py
+++ b/tests/units/test_configuration_version.py
@@ -164,7 +164,7 @@ class TestConfigurationVersionsList:
 
         workspace_id = "ws-YnyXLq9fy38afEeb"
         options = ConfigurationVersionListOptions(
-            include=[ConfigVerIncludeOpt.INGRESS_ATTRIBUTES], page_size=5, page_number=1
+            include=[ConfigVerIncludeOpt.INGRESS_ATTRIBUTES], page_size=5
         )
 
         list(configuration_versions_service.list(workspace_id, options))
@@ -173,7 +173,7 @@ class TestConfigurationVersionsList:
         expected_params = {
             "include": "ingress_attributes",
             "page[size]": "5",
-            "page[number]": "1",
+            "page[number]": 1,
         }
         mock_transport.request.assert_called_with(
             "GET",

--- a/tests/units/test_workspace_resources.py
+++ b/tests/units/test_workspace_resources.py
@@ -143,7 +143,7 @@ class TestWorkspaceResourcesService:
         mock_transport.request.return_value = mock_response
 
         # Create options
-        options = WorkspaceResourceListOptions(page_number=2, page_size=50)
+        options = WorkspaceResourceListOptions(page_number=1, page_size=50)
 
         # Call the service
         result = list(service.list("ws-abc123", options))
@@ -152,7 +152,7 @@ class TestWorkspaceResourcesService:
         mock_transport.request.assert_called_once_with(
             "GET",
             "/api/v2/workspaces/ws-abc123/resources",
-            params={"page[number]": 2, "page[size]": 50},
+            params={"page[number]": 1, "page[size]": 50},
         )
 
         # Verify response

--- a/tests/units/test_workspaces.py
+++ b/tests/units/test_workspaces.py
@@ -751,14 +751,14 @@ class TestWorkspaceOperations:
         """Test remote state consumers listing with pagination options."""
         mock_transport.request.return_value.json.return_value = {"data": []}
 
-        options = WorkspaceListRemoteStateConsumersOptions(page_number=2, page_size=5)
+        options = WorkspaceListRemoteStateConsumersOptions(page_size=5)
 
         list(workspaces_service.list_remote_state_consumers("ws-123", options))
 
         # Verify pagination parameters were passed
         call_args = mock_transport.request.call_args
         params = call_args[1]["params"]
-        assert params["page[number]"] == 2
+        assert params["page[number]"] == 1
         assert params["page[size]"] == 5
 
     def test_add_remote_state_consumers_basic(self, workspaces_service, mock_transport):
@@ -921,7 +921,7 @@ class TestWorkspaceOperations:
         """Test tag listing with query and pagination options."""
         mock_transport.request.return_value.json.return_value = {"data": []}
 
-        options = WorkspaceTagListOptions(query="env", page_number=2, page_size=5)
+        options = WorkspaceTagListOptions(query="env", page_size=5)
 
         list(workspaces_service.list_tags("ws-123", options))
 
@@ -929,7 +929,7 @@ class TestWorkspaceOperations:
         call_args = mock_transport.request.call_args
         params = call_args[1]["params"]
         assert params["name"] == "env"
-        assert params["page[number]"] == 2
+        assert params["page[number]"] == 1
         assert params["page[size]"] == 5
 
     def test_add_tags_basic(self, workspaces_service, mock_transport):


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/python-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->

_list pagination in _base.py can repeatedly request page 1 and appear to hang (or loop indefinitely) when callers pass page[number] in params and use smaller page[size].

The current logic uses setdefault("page[number]", page) inside the loop.
When params already contains page[number] (for example from RunListOptions), setdefault does not overwrite it, so the request stays pinned to the same page even though page += 1 executes.

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->
[Issue102](https://github.com/hashicorp/python-tfe/issues/102)
[JIRA](https://hashicorp.atlassian.net/browse/TF-35310)

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->

<img width="1238" height="498" alt="image" src="https://github.com/user-attachments/assets/a364f400-e58e-4909-9a0c-7e924a0433c9" />


```
python examples/run.py --organization sandbox --page-size 2

================================================================================
Listing runs across organization: sandbox
================================================================================
Found 12 runs across organization
- run-6dk7frv2Jup | status=RunStatus.Run_Planned
- run-yAdFQuW | status=RunStatus.Run_Planned
- run-9me6qitsR3 | status=RunStatus.Run_Errored
- run-yyrBwjS | status=RunStatus.Run_Errored
- run-BDn8sXmuP | status=RunStatus.Run_Errored
- run-Se5YLhhDh | status=RunStatus.Run_Applied
- run-9SX7FLk | status=RunStatus.Run_Errored
- run-56P1iMnrnG | status=RunStatus.Run_Errored
- run-zMffwuE9 | status=RunStatus.Run_Errored
- run-vjaXmp | status=RunStatus.Run_Errored
- run-gTnXiDfzj3 | status=RunStatus.Run_Errored
- run-b3TLLbmxJ | status=RunStatus.Run_Errored
```

## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).
