### PR TITLE
policy check read handles nested data

### DIFF
--- a/src/pytfe/resources/policy_check.py
+++ b/src/pytfe/resources/policy_check.py
@@ -43,7 +43,7 @@ class PolicyChecks(_Service):
         for d in jd.get("data", []):
             attrs = d.get("attributes", {})
             attrs["id"] = d.get("id")
-            attrs["run"] = d.get("relationships", {}).get("run", {})
+            attrs["run"] = d.get("relationships", {}).get("run", {}).get("data", {})
             items.append(PolicyCheck.model_validate(attrs))
         return PolicyCheckList(
             items=items,
@@ -66,7 +66,7 @@ class PolicyChecks(_Service):
         d = jd.get("data", {})
         attrs = d.get("attributes", {})
         attrs["id"] = d.get("id")
-        attrs["run"] = d.get("relationships", {}).get("run", {})
+        attrs["run"] = d.get("relationships", {}).get("run", {}).get("data", {})
         return PolicyCheck.model_validate(attrs)
 
     def override(self, policy_check_id: str) -> PolicyCheck:

--- a/tests/units/test_policy_check.py
+++ b/tests/units/test_policy_check.py
@@ -1,0 +1,121 @@
+"""Unit tests for the policy evaluation module."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from pytfe._http import HTTPTransport
+from pytfe.errors import InvalidRunIDError
+from pytfe.models.policy_check import (
+    PolicyCheck,
+    PolicyCheckListOptions,
+    PolicyStatus,
+)
+from pytfe.resources.policy_check import PolicyChecks
+
+
+class TestPolicyChecks:
+    """Test the PolicyChecks service class."""
+
+    @pytest.fixture
+    def mock_transport(self):
+        """Create a mock HTTPTransport."""
+        return Mock(spec=HTTPTransport)
+
+    @pytest.fixture
+    def policy_checks_service(self, mock_transport):
+        """Create a PolicyChecks service with mocked transport."""
+        return PolicyChecks(mock_transport)
+
+    def test_list_validations(self, policy_checks_service):
+        """Test list method with invalid task stage ID."""
+
+        # Test empty run ID
+        with pytest.raises(InvalidRunIDError):
+            list(policy_checks_service.list(""))
+
+        # Test None run ID
+        with pytest.raises(InvalidRunIDError):
+            list(policy_checks_service.list(None))
+
+    def test_list_success_with_options(self, policy_checks_service, mock_transport):
+        """Test successful iteration with custom pagination options."""
+
+        mock_response_data = {
+            "data": [
+                {
+                    "id": "polchk-9VYRc9bpfJEsnwum",
+                    "type": "policy-checks",
+                    "attributes": {
+                        "result": {
+                            "result": False,
+                            "passed": 0,
+                            "total-failed": 1,
+                            "hard-failed": 0,
+                            "soft-failed": 1,
+                            "advisory-failed": 0,
+                            "duration-ms": 0,
+                            "sentinel": {},
+                        },
+                        "scope": "organization",
+                        "status": "soft_failed",
+                        "status-timestamps": {
+                            "queued-at": "2017-11-29T20:02:17+00:00",
+                            "soft-failed-at": "2017-11-29T20:02:20+00:00",
+                        },
+                        "actions": {"is-overridable": True},
+                        "permissions": {"can-override": True},
+                    },
+                    "relationships": {
+                        "run": {"data": {"id": "run-veDoQbv6xh6TbnJD", "type": "runs"}}
+                    },
+                    "links": {
+                        "output": "/api/v2/policy-checks/polchk-9VYRc9bpfJEsnwum/output"
+                    },
+                }
+            ]
+        }
+
+        mock_response = Mock()
+        mock_response.json.return_value = mock_response_data
+        mock_transport.request.return_value = mock_response
+
+        options = PolicyCheckListOptions(page_size=5)  # type: ignore
+        result = policy_checks_service.list("run-123", options=options)
+
+        # Verify the request was made with correct parameters
+        assert mock_transport.request.call_count == 1
+        call_args = mock_transport.request.call_args
+        assert call_args[0][0] == "GET"
+        assert call_args[0][1] == "/api/v2/runs/run-123/policy-checks"
+
+        # Verify custom options were passed and merged with _list defaults
+        params = call_args[1]["params"]
+        assert params["page[size]"] == 5  # Custom value from options
+
+        # Verify the result
+        print(type(result))
+        assert len(result.items) == 1
+        assert isinstance(result.items[0], PolicyCheck)
+        assert result.items[0].id == "polchk-9VYRc9bpfJEsnwum"
+        assert result.items[0].status == PolicyStatus.POLICY_SOFT_FAILED
+        assert result.items[0].result.advisory_failed == 0
+        assert result.items[0].result.total_failed == 1
+
+    def test_list_empty_result(self, policy_checks_service, mock_transport):
+        """Test iteration with no results."""
+
+        mock_response_data = {"data": []}
+
+        mock_response = Mock()
+        mock_response.json.return_value = mock_response_data
+        mock_transport.request.return_value = mock_response
+
+        result = policy_checks_service.list("run-empty")
+
+        # Verify the request was made
+        assert mock_transport.request.call_count == 1
+
+        # Verify iterator yields no items
+        assert len(result.items) == 0
+        assert result.items == []


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/python-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

The logic for handling policy-checks doesn't currently account for the data being nested within a `data` field within the `run` entry in the relationships. this makes every attempt to read policy check results fail.



## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->
```python
    config = TFEConfig(address="https://app.terraform.io", token=TFE_TOKEN)
    tfe_client = TFEClient(config)        
    run_details = tfe_client.runs.read(run_id)
    print(f"run details: {run_details}\n\n")
    print(f"policy checks: {run_details.policy_checks}")
    for policy_check in run_details.policy_checks:
        print(f"policy check: {policy_check}")
        policy_check_id = policy_check.id
        print(f"policy check id: {policy_check_id}")
        policy_check_details = tfe_client.policy_checks.read(policy_check_id) # This line fails without this PR
```

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._



-->
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/policy-checks)

## Output from tests
```bash
.venv) richardboyd@Richards-MacBook-Pro python-tfe % make test
.venv/bin/python -m pytest -v
========================================== test session starts ===========================================
platform darwin -- Python 3.14.2, pytest-9.0.2, pluggy-1.6.0 -- /Users/richardboyd/Developer/python-tfe/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/richardboyd/Developer/python-tfe
configfile: pyproject.toml
plugins: anyio-4.12.1, mock-3.15.1
collected 396 items                                                                                      

tests/units/test_agent_pools.py::TestAgentPoolModels::test_agent_pool_model_basic PASSED           [  0%]
tests/units/test_agent_pools.py::TestAgentPoolModels::test_agent_pool_allowed_workspace_policy_enum PASSED [  0%]

[omitted for brevity]


tests/units/test_workspaces.py::TestWorkspaceOperations::test_set_data_retention_policy_dont_delete PASSED [ 99%]
tests/units/test_workspaces.py::TestWorkspaceOperations::test_set_data_retention_policy_legacy PASSED [ 99%]
tests/units/test_workspaces.py::TestWorkspaceOperations::test_delete_data_retention_policy PASSED  [100%]

========================================== 396 passed in 1.00s ===========================================
```

New unit test for Policy Checks

```bash
(.venv) richardboyd@Richards-MacBook-Pro python-tfe % python -m pytest tests/units/test_policy_check.py -v
======================================================= test session starts =======================================================
platform darwin -- Python 3.14.2, pytest-9.0.2, pluggy-1.6.0 -- /Users/richardboyd/Developer/python-tfe/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/richardboyd/Developer/python-tfe
configfile: pyproject.toml
plugins: anyio-4.12.1, mock-3.15.1
collected 3 items                                                                                                                 

tests/units/test_policy_check.py::TestPolicyChecks::test_list_validations PASSED                                            [ 33%]
tests/units/test_policy_check.py::TestPolicyChecks::test_list_success_with_options PASSED                                   [ 66%]
tests/units/test_policy_check.py::TestPolicyChecks::test_list_empty_result PASSED                                           [100%]

======================================================== 3 passed in 0.19s ========================================================
```

## Rollback Plan

git revert?

## Changes to Security Controls

N/A

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [N/A] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [N/A] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).
