### PR TITLE
update Run Relationships

### DIFF
--- a/src/pytfe/resources/run.py
+++ b/src/pytfe/resources/run.py
@@ -10,6 +10,12 @@ from ..errors import (
     RequiredWorkspaceError,
     TerraformVersionValidForPlanOnlyError,
 )
+from ..models.apply import Apply
+from ..models.comment import Comment
+from ..models.configuration_version import ConfigurationVersion
+from ..models.cost_estimate import CostEstimate
+from ..models.plan import Plan
+from ..models.policy_check import PolicyCheck
 from ..models.run import (
     Run,
     RunApplyOptions,
@@ -21,8 +27,55 @@ from ..models.run import (
     RunListOptions,
     RunReadOptions,
 )
+from ..models.run_event import RunEvent
+from ..models.task_stage import TaskStage
+from ..models.user import User
+from ..models.workspace import Workspace
 from ..utils import _safe_str, valid_string, valid_string_id
 from ._base import _Service
+
+
+def transform_relationships(relationships: dict) -> Any:
+    """
+    Transform relationships dict to map relationship names to their model objects.
+    Single IDs become model instances, multiple IDs become lists of model instances.
+    """
+    result = {}
+
+    # Map relationship keys to their model constructors
+    model_map = {
+        "apply": Apply,
+        "configuration-version": ConfigurationVersion,
+        "cost-estimate": CostEstimate,
+        "created-by": User,
+        "confirmed-by": User,
+        "plan": Plan,
+        "workspace": Workspace,
+        "policy-checks": PolicyCheck,
+        "run-events": RunEvent,
+        "task-stages": TaskStage,
+        "comments": Comment,
+    }
+
+    for key, value in relationships.items():
+        data = value.get("data")
+
+        if data is None:
+            continue
+
+        model_class = model_map.get(key)
+        if not model_class:
+            # Unknown relationship type, skip it
+            continue
+
+        if isinstance(data, list):
+            # Multiple entries - create list of model instances
+            result[key] = [model_class(id=item["id"]) for item in data if "id" in item]
+        elif isinstance(data, dict) and "id" in data:
+            # Single entry - create model instance
+            result[key] = model_class(id=data["id"])
+
+    return result
 
 
 class Runs(_Service):
@@ -94,10 +147,11 @@ class Runs(_Service):
         )
         d = r.json().get("data", {})
         attrs = d.get("attributes", {})
-        return Run(
-            id=_safe_str(d.get("id")),
-            **{k.replace("-", "_"): v for k, v in attrs.items()},
-        )
+        relationships = transform_relationships(d.get("relationships", {}))
+        combined = {
+            k.replace("-", "_"): v for k, v in {**attrs, **relationships}.items()
+        }
+        return Run(id=_safe_str(d.get("id")), **combined)
 
     def read(self, run_id: str) -> Run:
         """Read a run by its ID."""
@@ -119,10 +173,11 @@ class Runs(_Service):
         )
         d = r.json().get("data", {})
         attrs = d.get("attributes", {})
-        return Run(
-            id=_safe_str(d.get("id")),
-            **{k.replace("-", "_"): v for k, v in attrs.items()},
-        )
+        relationships = transform_relationships(d.get("relationships", {}))
+        combined = {
+            k.replace("-", "_"): v for k, v in {**attrs, **relationships}.items()
+        }
+        return Run(id=_safe_str(d.get("id")), **combined)
 
     def apply(self, run_id: str, options: RunApplyOptions | None = None) -> None:
         """Apply a run by its ID."""

--- a/tests/units/test_run.py
+++ b/tests/units/test_run.py
@@ -294,14 +294,113 @@ class TestRuns:
         mock_response_data = {
             "data": {
                 "id": "run-detailed-123",
+                "type": "runs",
                 "attributes": {
-                    "status": "planned",
-                    "source": "tfe-api",
-                    "message": "Detailed read test",
-                    "created-at": "2023-01-01T12:00:00Z",
+                    "actions": {
+                        "is-cancelable": False,
+                        "is-confirmable": False,
+                        "is-discardable": False,
+                        "is-force-cancelable": False,
+                    },
+                    "allow-config-generation": False,
+                    "allow-empty-apply": False,
+                    "auto-apply": False,
+                    "canceled-at": None,
+                    "created-at": "2026-02-19T01:58:46.126Z",
                     "has-changes": True,
                     "is-destroy": False,
+                    "message": "Triggered via CLI",
+                    "plan-only": False,
+                    "refresh": True,
+                    "refresh-only": False,
+                    "replace-addrs": None,
+                    "save-plan": False,
+                    "source": "terraform+cloud",
+                    "status-timestamps": {
+                        "errored-at": "2026-02-19T01:59:19+00:00",
+                        "planned-at": "2026-02-19T01:59:16+00:00",
+                        "queuing-at": "2026-02-19T01:58:46+00:00",
+                        "planning-at": "2026-02-19T01:58:48+00:00",
+                        "plan-queued-at": "2026-02-19T01:58:46+00:00",
+                        "plan-queueable-at": "2026-02-19T01:58:46+00:00",
+                    },
+                    "status": "errored",
+                    "target-addrs": None,
+                    "trigger-reason": "manual",
+                    "terraform-version": "1.13.5",
+                    "updated-at": "2026-02-19T01:59:19.891Z",
+                    "permissions": {
+                        "can-apply": True,
+                        "can-cancel": True,
+                        "can-comment": True,
+                        "can-discard": True,
+                        "can-force-execute": True,
+                        "can-force-cancel": True,
+                        "can-override-policy-check": True,
+                    },
+                    "variables": [],
+                    "invoke-action-addrs": None,
                 },
+                "relationships": {
+                    "workspace": {
+                        "data": {"id": "ws-a2Kntu53K79hsPRH", "type": "workspaces"}
+                    },
+                    "apply": {
+                        "data": {"id": "apply-Y1rVt6MpiwzdMjbK", "type": "applies"},
+                        "links": {"related": "/api/v2/runs/run-detailed-123/apply"},
+                    },
+                    "configuration-version": {
+                        "data": {
+                            "id": "cv-bakH4hn9cPXb2yZq",
+                            "type": "configuration-versions",
+                        },
+                        "links": {
+                            "related": "/api/v2/runs/run-detailed-123/configuration-version"
+                        },
+                    },
+                    "created-by": {
+                        "data": {"id": "user-FRJGnNMX6fpe9Cdd", "type": "users"},
+                        "links": {
+                            "related": "/api/v2/runs/run-detailed-123/created-by"
+                        },
+                    },
+                    "plan": {
+                        "data": {"id": "plan-WooDdHWZnSE3Zs8j", "type": "plans"},
+                        "links": {"related": "/api/v2/runs/run-detailed-123/plan"},
+                    },
+                    "run-events": {
+                        "data": [
+                            {"id": "re-bqJGaaCrt5QZfexJ", "type": "run-events"},
+                            {"id": "re-j8d6eWyfyHSUbX7x", "type": "run-events"},
+                            {"id": "re-UAXd9VyRTXZy3hpx", "type": "run-events"},
+                            {"id": "re-DFFf51Doi8mmHC9G", "type": "run-events"},
+                            {"id": "re-U2m4RMQhEY9voN1K", "type": "run-events"},
+                            {"id": "re-WWfUbu5NTWdYKgBs", "type": "run-events"},
+                        ],
+                        "links": {
+                            "related": "/api/v2/runs/run-detailed-123/run-events"
+                        },
+                    },
+                    "task-stages": {
+                        "data": [],
+                        "links": {
+                            "related": "/api/v2/runs/run-detailed-123/task-stages"
+                        },
+                    },
+                    "policy-checks": {
+                        "data": [
+                            {"id": "polchk-JxgtJ56kFifnngyT", "type": "policy-checks"}
+                        ],
+                        "links": {
+                            "related": "/api/v2/runs/run-detailed-123/policy-checks"
+                        },
+                    },
+                    "comments": {
+                        "data": [],
+                        "links": {"related": "/api/v2/runs/run-detailed-123/comments"},
+                    },
+                },
+                "links": {"self": "/api/v2/runs/run-detailed-123"},
             }
         }
 
@@ -330,6 +429,10 @@ class TestRuns:
             # Verify result
             assert isinstance(result, Run)
             assert result.id == "run-detailed-123"
+            assert result.created_by.id == "user-FRJGnNMX6fpe9Cdd"
+            assert result.plan.id == "plan-WooDdHWZnSE3Zs8j"
+            assert result.apply.id == "apply-Y1rVt6MpiwzdMjbK"
+            assert result.workspace.id == "ws-a2Kntu53K79hsPRH"
 
     def test_apply_run_success(self, runs_service):
         """Test successful apply operation."""


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/python-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description
based on [this issue](https://github.com/hashicorp/python-tfe/issues/87) items that aren't included in the 'attributes' part of a response were being dropped when the model is being constructed from the API response.

## Testing plan

1. I created a run in HCP Terraform and saved the run id (`"run-ugBnsFDyDviC876w"`)
2. I used the following code to fetch the response that the API returns
```python
    config = TFEConfig(address="https://app.terraform.io", token=tf_api_key)
    tfe_client = TFEClient(config)
    run_id="run-ugBnsFDyDviC876w"
    options = RunReadOptions(
                include=[
                    RunIncludeOpt.RUN_PLAN,
                    RunIncludeOpt.RUN_APPLY,
                    RunIncludeOpt.RUN_CREATED_BY,
                ]
            )
    run = tfe_client.runs.read_with_options(run_id, options=options)
```

3. I intercepted the response before we start parsing it by hot-patching the `run.py` file locally.
```python
        r = self.t.request(
            "GET",
            f"/api/v2/runs/{run_id}",
            params=params,
        )
        d = r.json().get("data", {})
        #### my code bloew
        import json
        print(json.dumps(d, indent=2))
```
4. I used the json reponse from the API as a test case to run the existing `run-detailed-123` case and found that it failed if I added an assertion `assert result.created_by.id == "user-FRJGnNMX6fpe9Cdd"`

5. updated the `run.py` resource to properly handle the response items that are not nested within `attributes` (i.e. `relationships`)

## External links
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run#get-run-details)


## Output from tests

```text
(.venv) richardboyd@Richards-MBP python-tfe % python -m pytest tests/units/test_run.py -v
===================================================================== test session starts ======================================================================
platform darwin -- Python 3.14.2, pytest-9.0.2, pluggy-1.6.0 -- /Users/richardboyd/Developer/python-tfe/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/richardboyd/Developer/python-tfe
configfile: pyproject.toml
plugins: anyio-4.12.1, mock-3.15.1
collected 12 items                                                                                                                                             

tests/units/test_run.py::TestRuns::test_list_runs_success PASSED                                                                                         [  8%]
tests/units/test_run.py::TestRuns::test_list_for_organization_success PASSED                                                                             [ 16%]
tests/units/test_run.py::TestRuns::test_create_run_validation_errors PASSED                                                                              [ 25%]
tests/units/test_run.py::TestRuns::test_create_run_success PASSED                                                                                        [ 33%]
tests/units/test_run.py::TestRuns::test_read_run_validation_errors PASSED                                                                                [ 41%]
tests/units/test_run.py::TestRuns::test_read_run_success PASSED                                                                                          [ 50%]
tests/units/test_run.py::TestRuns::test_read_with_options_success PASSED                                                                                 [ 58%]
tests/units/test_run.py::TestRuns::test_apply_run_success PASSED                                                                                         [ 66%]
tests/units/test_run.py::TestRuns::test_cancel_run_success PASSED                                                                                        [ 75%]
tests/units/test_run.py::TestRuns::test_force_cancel_run_success PASSED                                                                                  [ 83%]
tests/units/test_run.py::TestRuns::test_force_execute_run_success PASSED                                                                                 [ 91%]
tests/units/test_run.py::TestRuns::test_discard_run_success PASSED                                                                                       [100%]

====================================================================== 12 passed in 0.23s ======================================================================
```

## Rollback Plan
N/A

## Changes to Security Controls
N/A

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [N/A] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [N/A] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).
