### PR TITLE
Add missing RunSource enum values for runs.list_for_organization

### DIFF
--- a/examples/run.py
+++ b/examples/run.py
@@ -130,6 +130,32 @@ def main():
                 except Exception as e:
                     print(f"Error reading run details: {e}")
 
+        # Demonstrate RunSource enum values
+        _print_header("Run Source Types Demonstration")
+
+        from pytfe.models.run import RunSource
+
+        print("Available Run Source types and their meanings:")
+        print(
+            f"- {RunSource.Run_Source_API.value}: Runs created via Terraform Enterprise/Cloud API"
+        )
+        print(
+            f"- {RunSource.Run_Source_Configuration_Version.value}: Runs triggered by VCS configuration version uploads"
+        )
+        print(f"- {RunSource.Run_Source_UI.value}: Runs created via Terraform Cloud UI")
+        print(
+            f"- {RunSource.Run_Source_Terraform_Cloud.value}: Runs from Terraform CLI with cloud backend"
+        )
+        print(f"- {RunSource.Run_Source_Terraform.value}: Runs from Terraform CLI")
+        print(
+            f"- {RunSource.Run_Source_Run_Trigger.value}: Runs triggered by run triggers"
+        )
+        print(
+            f"- {RunSource.Run_Source_Infra_Lifecycle.value}: Runs from infrastructure lifecycle events"
+        )
+        print()
+        print("The SDK now supports all these run source types for proper validation.")
+
         # 3) Optionally create a new run
         if args.create_run:
             _print_header("Creating a new plan-only run")
@@ -218,7 +244,7 @@ def main():
             print("No runs available for actions demo")
             return
 
-        demo_run = run_list.items[0]
+        demo_run = run_list[0]
         print(f"Demonstrating actions for run: {demo_run.id}")
         print(f"Current status: {demo_run.status}")
 

--- a/src/pytfe/models/run.py
+++ b/src/pytfe/models/run.py
@@ -24,6 +24,9 @@ class RunSource(str, Enum):
     Run_Source_Configuration_Version = "tfe-configuration-version"
     Run_Source_UI = "tfe-ui"
     Run_Source_Terraform_Cloud = "terraform+cloud"
+    Run_Source_Terraform = "terraform"
+    Run_Source_Run_Trigger = "tfe-run-trigger"
+    Run_Source_Infra_Lifecycle = "tfe-infrastructure-lifecycle"
 
 
 class RunStatus(str, Enum):

--- a/tests/units/test_run.py
+++ b/tests/units/test_run.py
@@ -417,3 +417,37 @@ class TestRuns:
             assert call_args[0][0] == "POST"
             assert call_args[0][1] == "/api/v2/runs/run-discard-123/actions/discard"
             assert call_args[1]["json_body"]["comment"] == "Discarding run"
+
+    def test_run_source_enum_values(self):
+        """Test that all RunSource enum values work with Run model validation."""
+
+        # Test all RunSource enum values
+        test_sources = [
+            ("tfe-api", RunSource.Run_Source_API),
+            ("tfe-configuration-version", RunSource.Run_Source_Configuration_Version),
+            ("tfe-ui", RunSource.Run_Source_UI),
+            ("terraform+cloud", RunSource.Run_Source_Terraform_Cloud),
+            ("terraform", RunSource.Run_Source_Terraform),
+            ("tfe-run-trigger", RunSource.Run_Source_Run_Trigger),
+            ("tfe-infrastructure-lifecycle", RunSource.Run_Source_Infra_Lifecycle),
+        ]
+
+        for source_value, expected_enum in test_sources:
+            # Test that Run model can be created with this source
+            # Use the same format as the service methods (attributes flattened with id)
+            run_data = {
+                "id": f"run-test-{source_value.replace('+', '').replace('-', '_')}",
+                "status": "pending",
+                "source": source_value,
+                "message": f"Test run with source {source_value}",
+                "created-at": "2023-01-01T12:00:00Z",
+                "has-changes": False,
+                "is-destroy": False,
+            }
+
+            # This should not raise an exception
+            run = Run.model_validate(run_data)
+
+            # Verify the source was correctly parsed
+            assert run.source == expected_enum
+            assert run.source.value == source_value


### PR DESCRIPTION
- Add terraform, tfe-run-trigger, and tfe-infrastructure-lifecycle sources
- Add comprehensive unit tests for all RunSource enum values
- Update example file to demonstrate all run source types
- Fix bug in example file list indexing
- Apply proper code formatting

<!--
Thank you for contributing to hashicorp/python-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

This PR adds missing RunSource enum values to support all run sources returned by the Terraform Cloud API. The runs.list_for_organization method was failing to retrieve runs with certain source types due to incomplete enum definitions.

Motivation and Context
The runs.list_for_organization method was failing when encountering runs with source values like "terraform", "tfe-run-trigger", and "tfe-infrastructure-lifecycle" because these weren't defined in the RunSource enum. This caused Pydantic validation errors when the API returned runs with these source types, preventing users from listing all runs in their organization.

Type of Change
 Bug fix (non-breaking change which fixes an issue)
 New feature (non-breaking change which adds functionality)

Changes Made
Change 1: Enhanced RunSource enum with missing values

Added Run_Source_Terraform = "terraform" for Terraform CLI runs
Added Run_Source_Run_Trigger = "tfe-run-trigger"  for run trigger initiated runs
Added [Run_Source_Infra_Lifecycle = "tfe-infrastructure-lifecycle" for infrastructure lifecycle runs
This ensures complete coverage of all run sources returned by the Terraform Cloud API


Change 2: Added comprehensive unit tests

Created test_run_source_enum_values()
Tests all 7 RunSource enum values to ensure proper validation
Validates that Run model accepts all source types without errors


Change 3: Updated example file with demonstrations

Added RunSource import to run.py
Added "Run Source Types Demonstration" section showing all source types with descriptions
Fixed bug in run actions demo where run_list.items[0] should be run_list[0]


Implementation Details -
Architecture Changes
No architectural changes. This is an enhancement to the existing RunSource enum to support additional API values.

Key Files Changed
run.py : Added 3 new RunSource enum values for complete API coverage

test_run.py = Added comprehensive test coverage for all RunSource enum values
run.py =  Updated imports, added demonstration section, and fixed list indexing bug


## Testing plan

Unit Tests: All 13 run unit tests pass (including new test for enum values)

Code Quality: Formatting (Ruff), linting, and type checking all pass
Validation: Confirmed that Run model now accepts all 7 run source types without validation errors
Screenshots/Recordings
N/A - This is a backend/model enhancement with no UI changes.

## External links


- [API documentation] https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

Integration Tests: All 445 unit tests across the codebase pass

<img width="1159" height="922" alt="Screenshot 2026-03-30 at 11 11 39 AM" src="https://github.com/user-attachments/assets/8a77d13a-ee54-4eb5-91d0-a31b0ece5a7b" />
<img width="1026" height="906" alt="Screenshot 2026-03-30 at 11 12 15 AM" src="https://github.com/user-attachments/assets/5ecfccbf-9c85-41a2-bdce-019a0c4ab32c" />

Unit Tests: All 13 run unit tests pass (including new test for enum values)

<img width="1152" height="360" alt="Screenshot 2026-03-30 at 11 12 29 AM" src="https://github.com/user-attachments/assets/61e66b9a-0ec0-404d-a210-e3141feb915a" />

## Breaking Changes
No breaking changes. This is a backward-compatible enhancement that adds support for previously unsupported run source types. Existing code will continue to work as before, but now runs.list_for_organization will successfully retrieve all runs regardless of their source type.

## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

In the event this change needs to be rolled back, we can revert the changes by removing the newly added RunSource enum values and associated tests. The rollback can be performed within 1 business day by.

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->

No changes to security controls. This PR only adds missing enum values to support additional run source types returned by the Terraform Cloud API. There are no modifications to:

Access controls
Authentication/authorization logic
Encryption mechanisms
Logging functionality
Input validation (beyond expanding the allowed enum values)
Network security
Data handling

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).






