### PR TITLE
🚀 Add Explorer API (v2) support to `pytfe`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+## Features
+
+### Explorer API
+* Added Explorer resource support with query, CSV export, saved view CRUD, saved view result query, and saved view CSV export endpoints.
+
 # v0.1.3
 
 ## Enhancements

--- a/examples/explorer.py
+++ b/examples/explorer.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+# Copyright IBM Corp. 2025, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+"""
+================================================================================
+  Terraform Explorer API — walkthrough (TFEClient.explorer)
+================================================================================
+
+  https://developer.hashicorp.com/terraform/cloud-docs/api-docs/explorer
+
+  PUBLIC FUNCTIONS
+  ───────────────────────────────────────────────────
+    ┌────────────────────────┬────────────────────────────────────┬──────────────────────────────────────────────────────────────────────────────┬──────────────────────────────┐
+    │ Function               │ Purpose                            │ Input parameters                                                             │ Returns                      │
+    ├────────────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────┼──────────────────────────────┤
+    │ query                  │ Execute any Explorer query         │ organization: str; options: ExplorerQueryOptions                             │ Iterator[ExplorerRow]        │
+    │ export_csv             │ Export query results as CSV        │ organization: str; options: ExplorerQueryOptions                             │ str (CSV document)           │
+    │ list_saved_views       │ List saved Explorer views          │ organization: str                                                            │ Iterator[ExplorerSavedView]  │
+    │ create_saved_view      │ Create saved Explorer view         │ organization: str; options: ExplorerSavedViewCreateOptions                   │ ExplorerSavedView            │
+    │ read_saved_view        │ Fetch one saved view by id         │ organization: str; view_id: str                                              │ ExplorerSavedView            │
+    │ update_saved_view      │ Update saved view definition       │ organization: str; view_id: str; options: ExplorerSavedViewUpdateOptions     │ ExplorerSavedView            │
+    │ delete_saved_view      │ Remove saved view by id            │ organization: str; view_id: str                                              │ ExplorerSavedView            │
+    │ saved_view_results     │ Execute saved view, stream rows    │ organization: str; view_id: str                                              │ Iterator[ExplorerRow]        │
+    │ saved_view_results_csv │ Saved view results as CSV          │ organization: str; view_id: str                                              │ str (CSV; fallbacks)         │
+    └────────────────────────┴────────────────────────────────────┴──────────────────────────────────────────────────────────────────────────────┴──────────────────────────────┘
+    delete_saved_view: if the DELETE response has no JSON body, the client returns a
+      minimal ExplorerSavedView with the same id.
+    saved_view_results_csv: tries the saved-view CSV endpoint first; on failure it may
+      call export_csv after read_saved_view, or build CSV from saved_view_results.
+
+  INPUT AND OUTPUT MODELS (how to pass; allowed values)
+  ───────────────────────────────────────────────────────
+    Full column tables and operator semantics:
+      https://developer.hashicorp.com/terraform/cloud-docs/api-docs/explorer
+
+  Plain string parameters (no model)
+    - organization — First argument on every method: org name as str (non-empty; invalid
+      values raise InvalidOrgError).
+    - view_id — str for saved-view routes (non-empty; invalid values raise
+      InvalidExplorerSavedViewIDError). Use the id returned by list_saved_views or
+      create_saved_view.
+
+  ExplorerQueryOptions — second argument to query(org, options) and export_csv(org, options)
+    How to pass: build one instance and pass it by name, for example
+      ExplorerQueryOptions(view_type=ExplorerViewType.WORKSPACES, sort="-workspace_name",
+      filters=[ExplorerUrlFilter(...)]).
+    Required:
+      - view_type — ExplorerViewType (serialized to HTTP query key type). Allowed strings
+        per product docs: workspaces, tf_versions, providers, modules. This SDK also
+        defines resources for APIs that support that view.
+    Optional:
+      - sort — Comma-separated snake_case field names for the active view; prefix "-" for
+        descending order.
+      - fields — Comma-separated snake_case columns to return (must be valid for the view).
+      - page_number, page_size — Integers; page_number ≥ 1; page_size between 1 and 100.
+      - filters — List of ExplorerUrlFilter; combined with logical AND.
+
+  ExplorerUrlFilter — each element of ExplorerQueryOptions.filters
+    How to pass: ExplorerUrlFilter(index=0, field="workspace_name", operator="contains",
+      value="prod", value_index=0).
+    Allowed:
+      - index — int ≥ 0 (first filter is 0, then 1, 2, …).
+      - field — snake_case column name for the current view_type (see Explorer doc View Types).
+      - operator — one of: is, is_not, contains, does not contain, is_empty, is_not_empty,
+        gt, lt, gteq, lteq, is_before, is_after (use the exact token your API version documents;
+        each operator only applies to compatible field types).
+      - value — str; use ISO 8601 timestamps for is_before / is_after when filtering datetimes.
+      - value_index — must be 0.
+
+  ExplorerSavedViewCreateOptions — second argument to create_saved_view(org, options)
+    How to pass: ExplorerSavedViewCreateOptions(name="...", query_type=ExplorerViewType....,
+      query=ExplorerSavedQuery(...)).
+    Allowed:
+      - name — non-empty str.
+      - query_type — same ExplorerViewType set as view_type (JSON body key query-type).
+      - query — ExplorerSavedQuery (see below).
+
+  ExplorerSavedViewUpdateOptions — third argument to update_saved_view(org, view_id, options)
+    How to pass: ExplorerSavedViewUpdateOptions(name="...", query=ExplorerSavedQuery(...)).
+    PATCH replaces the stored query entirely—send a full ExplorerSavedQuery each time.
+
+  ExplorerSavedQuery — nested only inside create/update options
+    How to pass: ExplorerSavedQuery(query_type=ExplorerViewType.WORKSPACES, filter=[...],
+      fields=[...], sort=[...]).
+    Allowed:
+      - query_type — required; same values as ExplorerQueryOptions.view_type (JSON key type).
+      - filter — optional list of ExplorerSavedQueryFilter(field=..., operator=..., value=[...]).
+      - fields — optional list of snake_case column names.
+      - sort — optional list of field names; leading "-" on an entry means descending.
+
+  ExplorerSavedQueryFilter — one dict-like row inside ExplorerSavedQuery.filter
+    How to pass: ExplorerSavedQueryFilter(field="workspace_name", operator="contains",
+      value=["prod"]).
+    Allowed: field and operator follow the same rules as URL filters; value is always a
+      list of strings (even for a single operand).
+
+  Output models (return values only; you do not instantiate these for requests)
+    ExplorerRow — from query(), saved_view_results(): read .id, .row_type, .attributes.
+      .attributes is a dict of column values; keys may be hyphenated or snake_case depending
+      on the API field name.
+    ExplorerSavedView — from create_saved_view, read_saved_view, update_saved_view,
+      delete_saved_view, list_saved_views: .id, .name, .created_at, .query_type, .query.
+    str — from export_csv, saved_view_results_csv: raw CSV document body.
+    Iterator[...] — lazy streams; consume with for-loops or list(...) if you need a list.
+
+  SCRIPT SECTIONS
+  ───────────────
+    Sections 1 through 3 always run (read-only): query, export_csv, list_saved_views.
+    Sections 4 through 6 run when TFE_EXPLORER_VIEW_ID is set: read_saved_view,
+    saved_view_results, saved_view_results_csv.
+    Section 7 runs when TFE_EXPLORER_DEMO_MUTATIONS=1: create_saved_view,
+    update_saved_view, delete_saved_view.
+
+  HOW TO RUN
+  ──────────
+    From the repository root, install in editable mode, then execute this file:
+      pip install -e .
+      python examples/explorer.py
+
+
+  ENVIRONMENT VARIABLES
+  ─────────────────────
+    TFE_TOKEN                     Required. API token with Explorer access.
+    TFE_ADDRESS                   Optional. API base URL; defaults to https://app.terraform.io
+    TFE_ORGANIZATION              Optional. Organization name (the script substitutes a placeholder if unset).
+    TFE_EXPLORER_VIEW_ID          Optional. When set, exercises saved-view read and export paths (sections 4–6).
+    TFE_EXPLORER_DEMO_MUTATIONS   Optional. Allowed value to enable writes: 1 only.
+      Any other value skips section 7 (create, update, delete).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import textwrap
+import uuid
+
+from pytfe import TFEClient, TFEConfig
+from pytfe.errors import TFEError
+from pytfe.models import (
+    ExplorerQueryOptions,
+    ExplorerSavedQuery,
+    ExplorerSavedQueryFilter,
+    ExplorerSavedViewCreateOptions,
+    ExplorerSavedViewUpdateOptions,
+    ExplorerUrlFilter,
+    ExplorerViewType,
+)
+
+_LINE = "-" * 72
+
+
+def _banner(title: str, subtitle: str = "") -> None:
+    """Print a plain section divider and title for stdout readability."""
+    print(f"\n{_LINE}\n{title}")
+    if subtitle:
+        print(subtitle)
+    print(_LINE)
+
+
+def _print_csv_lines(label: str, csv_text: str, max_chars: int, max_lines: int) -> None:
+    """Print a readable, line-oriented slice of a CSV string without decorative framing."""
+    snippet = csv_text[:max_chars]
+    truncated = len(csv_text) > max_chars
+    lines = snippet.splitlines() or ([snippet] if snippet else ["(empty)"])
+    print(label)
+    for raw in lines[:max_lines]:
+        display = raw if len(raw) <= 68 else raw[:67] + "..."
+        print(f"  {display}")
+    if len(lines) > max_lines:
+        print(
+            f"  ... ({len(lines) - max_lines} more line(s) not shown in this preview)"
+        )
+    if truncated:
+        print(
+            f"  (Preview truncated by character limit; full length {len(csv_text):,} chars.)"
+        )
+
+
+def main() -> None:
+    """Execute the Explorer walkthrough; refer to the module docstring for API details."""
+    token = os.getenv("TFE_TOKEN")
+    if not token:
+        print(
+            "Error: TFE_TOKEN is not set. Export a valid API token before running this example."
+        )
+        sys.exit(1)
+
+    address = os.getenv("TFE_ADDRESS", "https://app.terraform.io")
+    org = os.getenv("TFE_ORGANIZATION", "your-org-name")
+    view_id = os.getenv("TFE_EXPLORER_VIEW_ID")
+    demo_mutations = os.getenv("TFE_EXPLORER_DEMO_MUTATIONS") == "1"
+
+    # TFEClient is the entry point for all Terraform Enterprise / HCP Terraform API
+    # access in this SDK. TFEConfig carries the base URL and bearer token; every
+    # resource (including explorer) uses the same underlying HTTP session.
+    client = TFEClient(TFEConfig(address=address, token=token))
+
+    _banner(
+        "Terraform Explorer API example",
+        f"Organization: {org!r}\nAPI base URL: {address}",
+    )
+
+    # -------------------------------------------------------------------------
+    # Step 1: client.explorer.query(organization, options)
+    # -------------------------------------------------------------------------
+    # Runs GET .../organizations/{org}/explorer with query-string parameters derived
+    # from ExplorerQueryOptions. Here we request the workspaces view, sort by
+    # workspace_name descending (leading hyphen in sort), and add a single URL-style
+    # filter (workspace_name contains "42"). The iterator yields ExplorerRow objects
+    # (id, row_type, attributes dict); we only print the first five rows.
+    _banner(
+        "Step 1 of 7: query()",
+        "Workspaces view, sorted by -workspace_name, filter workspace_name contains '42'.",
+    )
+    query_opts = ExplorerQueryOptions(
+        view_type=ExplorerViewType.WORKSPACES,
+        sort="-workspace_name",
+        filters=[
+            ExplorerUrlFilter(
+                index=0,
+                field="workspace_name",
+                operator="contains",
+                value="42",
+            ),
+        ],
+    )
+    try:
+        count = 0
+        for i, row in enumerate(client.explorer.query(org, query_opts)):
+            if i >= 5:
+                break
+            count += 1
+            name = row.attributes.get("workspace-name") or row.attributes.get(
+                "workspace_name"
+            )
+            print(f"  Row {count}:")
+            print(f"    id:               {row.id}")
+            print(f"    row_type:         {row.row_type!r}")
+            print(f"    workspace_name:  {name!r}")
+            print("    ---")
+        print(f"Summary: printed {count} row(s) (limit 5).")
+    except TFEError as e:
+        print(f"  API error: {e}")
+    except Exception as e:
+        print(f"  Error: {e}")
+
+    # -------------------------------------------------------------------------
+    # Step 2: client.explorer.export_csv(organization, options)
+    # -------------------------------------------------------------------------
+    # Same query parameters as query(), but the response is a single CSV document
+    # (full unpaged export per API semantics). We only print an opening slice so the
+    # terminal stays readable.
+    _banner(
+        "Step 2 of 7: export_csv()",
+        "Workspaces view, no filters; preview first 400 characters / up to 8 lines.",
+    )
+    try:
+        csv_text = client.explorer.export_csv(
+            org, ExplorerQueryOptions(view_type=ExplorerViewType.WORKSPACES)
+        )
+        _print_csv_lines(
+            "CSV preview (document may be large):",
+            csv_text,
+            max_chars=400,
+            max_lines=8,
+        )
+        print("Summary: export_csv completed.")
+    except TFEError as e:
+        print(f"  API error: {e}")
+    except Exception as e:
+        print(f"  Error: {e}")
+
+    # -------------------------------------------------------------------------
+    # Step 3: client.explorer.list_saved_views(organization)
+    # -------------------------------------------------------------------------
+    # GET .../organizations/{org}/explorer/views returns every saved Explorer view
+    # (saved query) in the organization. Each item is an ExplorerSavedView with id,
+    # name, query, and query_type.
+    _banner(
+        "Step 3 of 7: list_saved_views()",
+        "Iterate all saved views; print id, name, and query_type for each.",
+    )
+    try:
+        n = 0
+        for sv in client.explorer.list_saved_views(org):
+            n += 1
+            print(f"  Saved view {n}:")
+            print(f"    id:          {sv.id}")
+            print(f"    name:        {sv.name!r}")
+            print(f"    query_type:  {sv.query_type!r}")
+            print("    ---")
+        print(f"Summary: listed {n} saved view(s).")
+    except TFEError as e:
+        print(f"  API error: {e}")
+    except Exception as e:
+        print(f"  Error: {e}")
+
+    if view_id:
+        # ---------------------------------------------------------------------
+        # Step 4: client.explorer.read_saved_view(organization, view_id)
+        # ---------------------------------------------------------------------
+        # GET .../explorer/views/{view_id} fetches one saved view definition (not the
+        # materialized result rows). view_id must be an id returned by list or create.
+        _banner(
+            "Step 4 of 7: read_saved_view()",
+            f"view_id from TFE_EXPLORER_VIEW_ID: {view_id!r}",
+        )
+        try:
+            sv = client.explorer.read_saved_view(org, view_id)
+            print("  Saved view record:")
+            print(f"    id:          {sv.id}")
+            print(f"    name:        {sv.name!r}")
+            q_preview = textwrap.shorten(repr(sv.query), width=68, placeholder=" ...")
+            print(f"    query:       {q_preview}")
+            print(f"    query_type:  {sv.query_type!r}")
+            print("Summary: read_saved_view completed.")
+        except TFEError as e:
+            print(f"  API error: {e}")
+
+        # ---------------------------------------------------------------------
+        # Step 5: client.explorer.saved_view_results(organization, view_id)
+        # ---------------------------------------------------------------------
+        # GET .../explorer/views/{view_id}/results re-executes the saved query and
+        # streams ExplorerRow results (same shape as query()). We print the first three.
+        _banner(
+            "Step 5 of 7: saved_view_results()",
+            "First 3 rows from re-running the saved view query.",
+        )
+        try:
+            for i, row in enumerate(client.explorer.saved_view_results(org, view_id)):
+                if i >= 3:
+                    break
+                print(f"  Result row {i + 1}:")
+                print(f"    id:        {row.id}")
+                print(f"    row_type:  {row.row_type!r}")
+                print("    ---")
+            print("Summary: saved_view_results completed (limit 3 rows printed).")
+        except TFEError as e:
+            print(f"  API error: {e}")
+
+        # ---------------------------------------------------------------------
+        # Step 6: client.explorer.saved_view_results_csv(organization, view_id)
+        # ---------------------------------------------------------------------
+        # Intended to match GET .../explorer/views/{view_id}/csv. This SDK may fall
+        # back to export_csv after read_saved_view, or synthesize CSV from results,
+        # when the dedicated CSV route is unavailable.
+        _banner(
+            "Step 6 of 7: saved_view_results_csv()",
+            "Preview first 300 characters / up to 6 lines; fallbacks may apply.",
+        )
+        try:
+            csv_sv = client.explorer.saved_view_results_csv(org, view_id)
+            _print_csv_lines(
+                "CSV preview:",
+                csv_sv,
+                max_chars=300,
+                max_lines=6,
+            )
+            print("Summary: saved_view_results_csv completed.")
+        except TFEError as e:
+            print(f"  API error: {e}")
+            note = textwrap.fill(
+                "Note: A 404 often means the saved view was removed, the id belongs to "
+                "another organization, or this deployment has no dedicated CSV route. "
+                "The client retries via export_csv after read_saved_view, then builds "
+                "CSV from saved_view_results. If step 5 worked, confirm an editable "
+                "install (pip install -e .).",
+                width=70,
+                subsequent_indent="    ",
+            )
+            for line in note.splitlines():
+                print(f"  {line}")
+    else:
+        _banner(
+            "Steps 4 through 6 skipped",
+            "Set environment variable TFE_EXPLORER_VIEW_ID to the saved view id to run "
+            "read_saved_view, saved_view_results, and saved_view_results_csv.",
+        )
+
+    if demo_mutations:
+        suffix = uuid.uuid4().hex[:8]
+        base_name = f"python-tfe-explorer-example-{suffix}"
+        _banner(
+            "Step 7 of 7: create_saved_view, update_saved_view, delete_saved_view",
+            f"Uses a unique temporary name so reruns do not collide: {base_name!r}",
+        )
+        try:
+            # ExplorerSavedViewCreateOptions maps to POST .../explorer/views: a display
+            # name, the primary query_type for the saved definition, and an embedded
+            # ExplorerSavedQuery (view type, optional filters with list-valued operands).
+            create_opts = ExplorerSavedViewCreateOptions(
+                name=base_name,
+                query_type=ExplorerViewType.WORKSPACES,
+                query=ExplorerSavedQuery(
+                    query_type=ExplorerViewType.WORKSPACES,
+                    filter=[
+                        ExplorerSavedQueryFilter(
+                            field="workspace_name",
+                            operator="contains",
+                            value=["test"],
+                        )
+                    ],
+                ),
+            )
+            # client.explorer.create_saved_view persists a new saved view; the response
+            # includes the server-assigned id required for subsequent update/delete.
+            created = client.explorer.create_saved_view(org, create_opts)
+            print(f"  create_saved_view: new id {created.id}")
+
+            # ExplorerSavedViewUpdateOptions maps to PATCH: at minimum a new name and
+            # a full replacement ExplorerSavedQuery payload for the stored definition.
+            update_opts = ExplorerSavedViewUpdateOptions(
+                name=f"{base_name}-updated",
+                query=ExplorerSavedQuery(
+                    query_type=ExplorerViewType.WORKSPACES,
+                    filter=[
+                        ExplorerSavedQueryFilter(
+                            field="workspace_name",
+                            operator="contains",
+                            value=["demo"],
+                        )
+                    ],
+                ),
+            )
+            # client.explorer.update_saved_view applies the patch to the id returned
+            # from create_saved_view in this demonstration sequence.
+            updated = client.explorer.update_saved_view(org, created.id, update_opts)
+            print(f"  update_saved_view: name is now {updated.name!r}")
+
+            # client.explorer.delete_saved_view removes the saved view; some API
+            # responses omit JSON, in which case the client still returns a minimal
+            # ExplorerSavedView carrying the deleted id.
+            deleted = client.explorer.delete_saved_view(org, created.id)
+            print(f"  delete_saved_view: completed for id {deleted.id}")
+            print("Summary: mutation sequence finished.")
+        except TFEError as e:
+            print(f"  API error: {e}")
+            sys.exit(1)
+    else:
+        _banner(
+            "Step 7 skipped",
+            "Set TFE_EXPLORER_DEMO_MUTATIONS=1 to run create_saved_view, "
+            "update_saved_view, and delete_saved_view (writes to your organization).",
+        )
+
+    print(f"\n{_LINE}\nExample completed.\n{_LINE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/explorer.py
+++ b/examples/explorer.py
@@ -46,9 +46,8 @@
       ExplorerQueryOptions(view_type=ExplorerViewType.WORKSPACES, sort="-workspace_name",
       filters=[ExplorerUrlFilter(...)]).
     Required:
-      - view_type — ExplorerViewType (serialized to HTTP query key type). Allowed strings
-        per product docs: workspaces, tf_versions, providers, modules. This SDK also
-        defines resources for APIs that support that view.
+      - view_type — ExplorerViewType (serialized to HTTP query key type). Allowed values
+        match HashiCorp docs: workspaces, tf_versions, providers, modules.
     Optional:
       - sort — Comma-separated snake_case field names for the active view; prefix "-" for
         descending order.
@@ -355,7 +354,7 @@ def main() -> None:
             _print_csv_lines(
                 "CSV preview:",
                 csv_sv,
-                max_chars=300,
+                max_chars=500,
                 max_lines=6,
             )
             print("Summary: saved_view_results_csv completed.")

--- a/examples/explorer.py
+++ b/examples/explorer.py
@@ -428,11 +428,9 @@ def main() -> None:
             updated = client.explorer.update_saved_view(org, created.id, update_opts)
             print(f"  update_saved_view: name is now {updated.name!r}")
 
-            # client.explorer.delete_saved_view removes the saved view; some API
-            # responses omit JSON, in which case the client still returns a minimal
-            # ExplorerSavedView carrying the deleted id.
-            deleted = client.explorer.delete_saved_view(org, created.id)
-            print(f"  delete_saved_view: completed for id {deleted.id}")
+            # client.explorer.delete_saved_view removes the saved view and returns None.
+            client.explorer.delete_saved_view(org, created.id)
+            print(f"  delete_saved_view: completed for id {created.id}")
             print("Summary: mutation sequence finished.")
         except TFEError as e:
             print(f"  API error: {e}")

--- a/src/pytfe/client.py
+++ b/src/pytfe/client.py
@@ -9,6 +9,7 @@ from .resources.agent_pools import AgentPools
 from .resources.agents import Agents, AgentTokens
 from .resources.apply import Applies
 from .resources.configuration_version import ConfigurationVersions
+from .resources.explorer import Explorer
 from .resources.notification_configuration import NotificationConfigurations
 from .resources.oauth_client import OAuthClients
 from .resources.oauth_token import OAuthTokens
@@ -72,6 +73,9 @@ class TFEClient:
         self.plans = Plans(self._transport)
         self.organizations = Organizations(self._transport)
         self.organization_memberships = OrganizationMemberships(self._transport)
+        self.explorer = Explorer(
+            self._transport
+        )  # org Explorer queries and saved views
 
         self.projects = Projects(self._transport)
         self.variables = Variables(self._transport)

--- a/src/pytfe/errors.py
+++ b/src/pytfe/errors.py
@@ -372,6 +372,13 @@ class InvalidQueryRunIDError(InvalidValues):
         super().__init__(message)
 
 
+class InvalidExplorerSavedViewIDError(InvalidValues):
+    """Raised when a saved view id is missing or blank (Explorer view-scoped routes)."""
+
+    def __init__(self, message: str = "invalid value for explorer saved view ID"):
+        super().__init__(message)
+
+
 class TerraformVersionValidForPlanOnlyError(ValidationError):
     """Raised when terraform_version is set without plan_only being true."""
 

--- a/src/pytfe/models/__init__.py
+++ b/src/pytfe/models/__init__.py
@@ -58,6 +58,17 @@ from .data_retention_policy import (
     DataRetentionPolicyDontDeleteSetOptions,
     DataRetentionPolicySetOptions,
 )
+from .explorer import (
+    ExplorerQueryOptions,
+    ExplorerRow,
+    ExplorerSavedQuery,
+    ExplorerSavedQueryFilter,
+    ExplorerSavedView,
+    ExplorerSavedViewCreateOptions,
+    ExplorerSavedViewUpdateOptions,
+    ExplorerUrlFilter,
+    ExplorerViewType,
+)
 
 # ── OAuth ─────────────────────────────────────────────────────────────────────
 from .oauth_client import (
@@ -484,6 +495,16 @@ __all__ = [
     "QueryRunStatus",
     "QueryRunStatusTimestamps",
     "QueryRunVariable",
+    # Explorer
+    "ExplorerQueryOptions",
+    "ExplorerRow",
+    "ExplorerSavedQuery",
+    "ExplorerSavedQueryFilter",
+    "ExplorerSavedView",
+    "ExplorerSavedViewCreateOptions",
+    "ExplorerSavedViewUpdateOptions",
+    "ExplorerUrlFilter",
+    "ExplorerViewType",
     # Core (from old types.py, now split)
     "Entitlements",
     "ExecutionMode",

--- a/src/pytfe/models/explorer.py
+++ b/src/pytfe/models/explorer.py
@@ -16,13 +16,12 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class ExplorerViewType(str, Enum):
-    """Explorer `type` / `query-type` discriminator (see product docs for supported views)."""
+    """Explorer `type` / `query-type` discriminator (HashiCorp Explorer API view types only)."""
 
     WORKSPACES = "workspaces"
     TF_VERSIONS = "tf_versions"
     PROVIDERS = "providers"
     MODULES = "modules"
-    RESOURCES = "resources"  # Present when the deployment exposes a resources view.
 
 
 class ExplorerUrlFilter(BaseModel):

--- a/src/pytfe/models/explorer.py
+++ b/src/pytfe/models/explorer.py
@@ -1,0 +1,123 @@
+# Copyright IBM Corp. 2025, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+"""Pydantic models for the Explorer API (query options, rows, saved views).
+
+Aliases mirror JSON:API and Explorer query-string names (type, page[number], etc.).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ExplorerViewType(str, Enum):
+    """Explorer `type` / `query-type` discriminator (see product docs for supported views)."""
+
+    WORKSPACES = "workspaces"
+    TF_VERSIONS = "tf_versions"
+    PROVIDERS = "providers"
+    MODULES = "modules"
+    RESOURCES = "resources"  # Present when the deployment exposes a resources view.
+
+
+class ExplorerUrlFilter(BaseModel):
+    """One slot in ExplorerQueryOptions.filters → filter[i][field][op][idx] query keys."""
+
+    index: int = Field(..., ge=0, description="Filter index in the query string")
+    field: str = Field(
+        ..., min_length=1, description="Explorer field name in snake_case"
+    )
+    operator: str = Field(..., min_length=1, description="Explorer filter operator")
+    value: str = Field(..., description="Filter value")
+    value_index: int = Field(
+        0,
+        ge=0,
+        description="Reserved index for filter value; currently expected as zero",
+    )
+
+
+class ExplorerQueryOptions(BaseModel):
+    """GET /organizations/{org}/explorer (and export/csv) query string as structured fields."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    view_type: ExplorerViewType = Field(..., alias="type")
+    sort: str | None = Field(
+        None,
+        description="Sort field (snake_case); prefix with '-' for descending order",
+    )
+    fields: str | None = Field(
+        None,
+        description="Comma-separated list of fields to include in each row",
+    )
+    page_number: int | None = Field(None, alias="page[number]", ge=1)
+    page_size: int | None = Field(None, alias="page[size]", ge=1, le=100)
+    filters: list[ExplorerUrlFilter] | None = Field(
+        None,
+        description="Expanded filter objects mapped to filter[index][field][operator][value_index]",
+    )
+
+
+class ExplorerRow(BaseModel):
+    """One Explorer result row: json:api id/type plus flat attributes for the view."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    row_type: str = Field(..., alias="type")
+    attributes: dict[str, Any] = Field(default_factory=dict)
+
+
+class ExplorerSavedQueryFilter(BaseModel):
+    """One saved-view filter row (list-valued `value` matches create/update JSON)."""
+
+    field: str = Field(..., min_length=1)
+    operator: str = Field(..., min_length=1)
+    value: list[str] = Field(default_factory=list)
+
+
+class ExplorerSavedQuery(BaseModel):
+    """Nested query on a saved view: view type, filters, optional fields and sort lists."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    query_type: ExplorerViewType = Field(..., alias="type")
+    filter: list[ExplorerSavedQueryFilter] | None = None
+    fields: list[str] | None = None
+    sort: list[str] | None = None
+
+
+class ExplorerSavedView(BaseModel):
+    """Saved view resource: metadata plus embedded query (response and some request paths)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    name: str
+    created_at: datetime | None = Field(None, alias="created-at")
+    query: ExplorerSavedQuery = Field(...)
+    query_type: ExplorerViewType = Field(..., alias="query-type")
+
+
+class ExplorerSavedViewCreateOptions(BaseModel):
+    """POST .../explorer/views attributes: display name, top-level query-type, nested query."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    name: str = Field(..., min_length=1)
+    query_type: ExplorerViewType = Field(..., alias="query-type")
+    query: ExplorerSavedQuery
+
+
+class ExplorerSavedViewUpdateOptions(BaseModel):
+    """PATCH .../explorer/views/{id} attributes: name and full replacement query."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    name: str = Field(..., min_length=1)
+    query: ExplorerSavedQuery

--- a/src/pytfe/resources/_base.py
+++ b/src/pytfe/resources/_base.py
@@ -9,6 +9,18 @@ from typing import Any
 from .._http import HTTPTransport
 
 
+def _to_int(value: Any) -> int | None:
+    """Best-effort integer coercion for pagination metadata values."""
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
 class _Service:
     def __init__(self, t: HTTPTransport) -> None:
         self.t = t
@@ -16,20 +28,60 @@ class _Service:
     def _list(
         self, path: str, *, params: dict | None = None
     ) -> Iterator[dict[str, Any]]:
-        page = 1
+        base_params = dict(params or {})
+        page = int(base_params.get("page[number]", 1))
         while True:
-            p = dict(params or {})
+            p = dict(base_params)
             p["page[number]"] = page
             p.setdefault("page[size]", 100)
             r = self.t.request("GET", path, params=p)
 
             # Handle cases where r.json() returns None or is not a dict
             json_response = r.json()
-            if json_response is None:
+            if json_response is None or not isinstance(json_response, dict):
                 json_response = {}
 
             data = json_response.get("data", [])
+            if not isinstance(data, list):
+                data = []
             yield from data
+            if not data:
+                # Defensive stop: some endpoints can return inconsistent pagination
+                # metadata while yielding no rows; avoid unbounded follow-up requests.
+                break
+
+            # Prefer server pagination metadata when available. This avoids
+            # prematurely terminating when servers clamp requested page sizes.
+            meta = json_response.get("meta")
+            pagination = meta.get("pagination", {}) if isinstance(meta, dict) else {}
+            if isinstance(pagination, dict) and pagination:
+                next_page = _to_int(
+                    pagination.get("next-page", pagination.get("next_page"))
+                )
+                if next_page is not None and next_page > page:
+                    page = next_page
+                    continue
+
+                current_page = _to_int(
+                    pagination.get("current-page", pagination.get("current_page"))
+                )
+                total_pages = _to_int(
+                    pagination.get("total-pages", pagination.get("total_pages"))
+                )
+                if (
+                    current_page is not None
+                    and total_pages is not None
+                    and current_page < total_pages
+                ):
+                    candidate_page = current_page + 1
+                    if candidate_page > page:
+                        page = candidate_page
+                        continue
+
+                # Metadata present and indicates no next page.
+                break
+
+            # Fallback for endpoints that do not return pagination metadata.
             page_size = int(p["page[size]"])
             if len(data) < page_size:
                 break

--- a/src/pytfe/resources/explorer.py
+++ b/src/pytfe/resources/explorer.py
@@ -121,6 +121,11 @@ def _parse_row(item: dict[str, Any]) -> ExplorerRow:
     return ExplorerRow.model_validate(item)
 
 
+def _normalize_filter_field_name(raw_field: Any) -> str:
+    """Normalize filter field names to SDK model style."""
+    return str(raw_field).replace("-", "_")
+
+
 def _saved_query_to_api_shape(raw_query: dict[str, Any]) -> dict[str, Any]:
     """Map {field, operator, value} filter rows to nested {field: {operator: [...]}} JSON."""
     query = dict(raw_query)
@@ -134,7 +139,7 @@ def _saved_query_to_api_shape(raw_query: dict[str, Any]) -> dict[str, Any]:
             if "field" not in entry or "operator" not in entry:
                 mapped_filters.append(entry)
                 continue
-            field = str(entry.get("field", "")).replace("-", "_")
+            field = _normalize_filter_field_name(entry.get("field", ""))
             operator = str(entry.get("operator", ""))
             values = entry.get("value", [])
             if not isinstance(values, list):
@@ -166,7 +171,7 @@ def _normalize_saved_query(
                     value = [str(value)]
                 normalized_filters.append(
                     {
-                        "field": str(entry["field"]).replace("-", "_"),
+                        "field": _normalize_filter_field_name(entry["field"]),
                         "operator": str(entry["operator"]),
                         "value": [str(v) for v in value],
                     }
@@ -182,7 +187,7 @@ def _normalize_saved_query(
                         vals = values if isinstance(values, list) else [values]
                         normalized_filters.append(
                             {
-                                "field": str(field_name).replace("-", "_"),
+                                "field": _normalize_filter_field_name(field_name),
                                 "operator": str(operator),
                                 "value": [str(v) for v in vals],
                             }
@@ -216,18 +221,6 @@ def _parse_saved_view(item: dict[str, Any]) -> ExplorerSavedView:
             "created-at": attrs.get("created-at"),
             "query": _normalize_saved_query(query, query_type),
             "query-type": query_type,
-        }
-    )
-
-
-def _deleted_saved_view_fallback(view_id: str) -> ExplorerSavedView:
-    """Build a minimal saved view when delete responses have no body."""
-    return ExplorerSavedView.model_validate(
-        {
-            "id": view_id,
-            "name": "",
-            "query-type": "workspaces",
-            "query": {"type": "workspaces"},
         }
     )
 
@@ -550,38 +543,10 @@ class Explorer(_Service):
         _log.info("explorer.update_saved_view org=%r id=%r", organization, view.id)
         return view
 
-    def delete_saved_view(self, organization: str, view_id: str) -> ExplorerSavedView:
+    def delete_saved_view(self, organization: str, view_id: str) -> None:
         _require_organization_and_view(organization, view_id)
         path = f"/api/v2/organizations/{organization}/explorer/views/{view_id}"
-        resp = self.t.request("DELETE", path)
-        # DELETE often returns an empty body; callers still receive a minimal ExplorerSavedView.
-        raw_text = (resp.text or "").strip()
-        if not raw_text:
-            _log.debug(
-                "explorer.delete_saved_view: empty body, returning stub org=%r id=%r",
-                organization,
-                view_id,
-            )
-            return _deleted_saved_view_fallback(view_id)
-
-        try:
-            payload = resp.json()
-        except ValueError:
-            _log.debug(
-                "explorer.delete_saved_view: non-JSON body, returning stub org=%r id=%r",
-                organization,
-                view_id,
-            )
-            return _deleted_saved_view_fallback(view_id)
-
-        if isinstance(payload, dict) and isinstance(payload.get("data"), dict):
-            return _parse_saved_view(payload["data"])
-        _log.debug(
-            "explorer.delete_saved_view: no data object, returning stub org=%r id=%r",
-            organization,
-            view_id,
-        )
-        return _deleted_saved_view_fallback(view_id)
+        self.t.request("DELETE", path)
 
     def saved_view_results(
         self, organization: str, view_id: str

--- a/src/pytfe/resources/explorer.py
+++ b/src/pytfe/resources/explorer.py
@@ -445,6 +445,15 @@ class Explorer(_Service):
     def query(
         self, organization: str, options: ExplorerQueryOptions
     ) -> Iterator[ExplorerRow]:
+        """Execute an Explorer query and iterate result rows across all pages.
+
+        Args:
+            organization: Organization slug that owns the Explorer data.
+            options: Query options including view type, filters, sort, and paging.
+
+        Yields:
+            ExplorerRow items returned by the Explorer endpoint.
+        """
         _require_organization(organization)
         _log.debug(
             "explorer.query org=%r view_type=%s",
@@ -457,6 +466,15 @@ class Explorer(_Service):
             yield _parse_row(item)
 
     def export_csv(self, organization: str, options: ExplorerQueryOptions) -> str:
+        """Run an Explorer query and return CSV text from the export endpoint.
+
+        Args:
+            organization: Organization slug that owns the Explorer data.
+            options: Query options including view type, filters, sort, and paging.
+
+        Returns:
+            Raw CSV text returned by the server.
+        """
         _require_organization(organization)
         _log.debug(
             "explorer.export_csv org=%r view_type=%s",
@@ -469,6 +487,14 @@ class Explorer(_Service):
         return resp.text
 
     def list_saved_views(self, organization: str) -> Iterator[ExplorerSavedView]:
+        """Iterate all saved Explorer views in an organization.
+
+        Args:
+            organization: Organization slug that owns the saved views.
+
+        Yields:
+            ExplorerSavedView resources from the list endpoint.
+        """
         _require_organization(organization)
         _log.debug("explorer.list_saved_views org=%r", organization)
         # GET collection of explorer-saved-queries for the org.
@@ -479,6 +505,15 @@ class Explorer(_Service):
     def create_saved_view(
         self, organization: str, options: ExplorerSavedViewCreateOptions
     ) -> ExplorerSavedView:
+        """Create a saved Explorer view.
+
+        Args:
+            organization: Organization slug that owns the saved view.
+            options: Saved-view name and query definition to persist.
+
+        Returns:
+            The created ExplorerSavedView as returned by the API.
+        """
         _require_organization(organization)
         # POST json:api explorer-saved-queries; filters rewritten for server expectations.
         attrs = _write_attributes_with_query_shape(options)
@@ -498,6 +533,15 @@ class Explorer(_Service):
         return view
 
     def read_saved_view(self, organization: str, view_id: str) -> ExplorerSavedView:
+        """Read one saved Explorer view by id.
+
+        Args:
+            organization: Organization slug that owns the saved view.
+            view_id: Saved-view id (for example, ``sq-...``).
+
+        Returns:
+            The saved view definition and query metadata.
+        """
         _require_organization_and_view(organization, view_id)
         _log.debug(
             "explorer.read_saved_view org=%r view_id=%r",
@@ -521,6 +565,16 @@ class Explorer(_Service):
         view_id: str,
         options: ExplorerSavedViewUpdateOptions,
     ) -> ExplorerSavedView:
+        """Replace attributes of an existing saved Explorer view.
+
+        Args:
+            organization: Organization slug that owns the saved view.
+            view_id: Saved-view id (for example, ``sq-...``).
+            options: Updated name and full replacement query definition.
+
+        Returns:
+            The updated ExplorerSavedView as returned by the API.
+        """
         _require_organization_and_view(organization, view_id)
         attrs = _write_attributes_with_query_shape(options)
         # PATCH includes resource id in the envelope per json:api update conventions.
@@ -544,6 +598,15 @@ class Explorer(_Service):
         return view
 
     def delete_saved_view(self, organization: str, view_id: str) -> None:
+        """Delete a saved Explorer view.
+
+        Args:
+            organization: Organization slug that owns the saved view.
+            view_id: Saved-view id (for example, ``sq-...``).
+
+        Returns:
+            None.
+        """
         _require_organization_and_view(organization, view_id)
         path = f"/api/v2/organizations/{organization}/explorer/views/{view_id}"
         self.t.request("DELETE", path)
@@ -551,6 +614,15 @@ class Explorer(_Service):
     def saved_view_results(
         self, organization: str, view_id: str
     ) -> Iterator[ExplorerRow]:
+        """Execute a saved view and iterate result rows across all pages.
+
+        Args:
+            organization: Organization slug that owns the saved view.
+            view_id: Saved-view id (for example, ``sq-...``).
+
+        Yields:
+            ExplorerRow items produced by the saved query.
+        """
         _require_organization_and_view(organization, view_id)
         _log.debug(
             "explorer.saved_view_results org=%r view_id=%r",
@@ -563,6 +635,19 @@ class Explorer(_Service):
             yield _parse_row(item)
 
     def saved_view_results_csv(self, organization: str, view_id: str) -> str:
+        """Return CSV for a saved view with resilient fallback behavior.
+
+        Tries the dedicated saved-view CSV endpoint first, then falls back to replaying
+        the saved view through ``export_csv`` and finally to materializing rows from the
+        paginated results endpoint.
+
+        Args:
+            organization: Organization slug that owns the saved view.
+            view_id: Saved-view id (for example, ``sq-...``).
+
+        Returns:
+            CSV text for the saved view results.
+        """
         _require_organization_and_view(organization, view_id)
         _log.debug(
             "explorer.saved_view_results_csv org=%r view_id=%r",

--- a/src/pytfe/resources/explorer.py
+++ b/src/pytfe/resources/explorer.py
@@ -30,6 +30,7 @@ from ..models.explorer import (
     ExplorerSavedViewCreateOptions,
     ExplorerSavedViewUpdateOptions,
     ExplorerUrlFilter,
+    ExplorerViewType,
 )
 from ..utils import valid_string_id
 from ._base import _Service
@@ -259,19 +260,189 @@ def _query_options_from_saved_view(
     )
 
 
-def _rows_to_csv(rows: list[ExplorerRow]) -> str:
-    """Union of row attribute keys as header; last-resort CSV when /views/.../csv is unavailable."""
+# Column order matches HashiCorp Explorer API docs (view-type field tables and export/csv
+# workspaces sample): https://developer.hashicorp.com/terraform/cloud-docs/api-docs/explorer
+_EXPLORER_CSV_COLUMNS: dict[ExplorerViewType, tuple[str, ...]] = {
+    ExplorerViewType.WORKSPACES: (
+        "all_checks_succeeded",
+        "current_rum_count",
+        "checks_errored",
+        "checks_failed",
+        "checks_passed",
+        "checks_unknown",
+        "current_run_applied_at",
+        "current_run_external_id",
+        "current_run_status",
+        "drifted",
+        "external_id",
+        "module_count",
+        "modules",
+        "organization_name",
+        "project_external_id",
+        "project_name",
+        "provider_count",
+        "providers",
+        "resources_drifted",
+        "resources_undrifted",
+        "state_version_terraform_version",
+        "vcs_repo_identifier",
+        "workspace_created_at",
+        "workspace_name",
+        "workspace_terraform_version",
+        "workspace_updated_at",
+    ),
+    ExplorerViewType.TF_VERSIONS: ("version", "workspace_count", "workspaces"),
+    ExplorerViewType.PROVIDERS: (
+        "name",
+        "source",
+        "version",
+        "workspace_count",
+        "workspaces",
+    ),
+    ExplorerViewType.MODULES: (
+        "name",
+        "source",
+        "version",
+        "workspace_count",
+        "workspaces",
+    ),
+}
+
+_ROW_TYPE_TO_VIEW: dict[str, ExplorerViewType] = {
+    "visibility-workspace": ExplorerViewType.WORKSPACES,
+}
+
+
+def _infer_view_type_from_csv_header(header: list[str]) -> ExplorerViewType | None:
+    """Pick Explorer view type from CSV header names (no extra API call)."""
+    h = frozenset(header)
+    candidates: list[tuple[int, int, str, ExplorerViewType]] = []
+    for vt, cols in _EXPLORER_CSV_COLUMNS.items():
+        colset = frozenset(cols)
+        overlap = len(h & colset)
+        if overlap == 0:
+            continue
+        # Prefer more matching columns; tie-break to a narrower schema (e.g. tf_versions).
+        candidates.append((overlap, -len(colset), vt.value, vt))
+    if not candidates:
+        return None
+    _, _, _, vt = max(candidates)
+    return vt
+
+
+def _explorer_attribute_value(attrs: dict[str, Any], logical_snake: str) -> Any:
+    """Resolve API attribute keys (snake_case or kebab-case) for one logical Explorer column."""
+    hyphen = logical_snake.replace("_", "-")
+    if logical_snake in attrs:
+        return attrs[logical_snake]
+    if hyphen in attrs:
+        return attrs[hyphen]
+    return ""
+
+
+def _csv_fieldnames_for_explorer_rows(
+    rows: list[ExplorerRow],
+    view_type: ExplorerViewType | None,
+) -> tuple[list[str], frozenset[str]]:
+    """Doc-ordered columns first; trailing columns for attributes not in the doc schema."""
+    all_raw: set[str] = set()
+    for row in rows:
+        all_raw.update(row.attributes.keys())
+
+    order = _EXPLORER_CSV_COLUMNS.get(view_type) if view_type is not None else None
+    if not order:
+        seen: set[str] = set()
+        visit: list[str] = []
+        for row in rows:
+            for k in row.attributes:
+                if k not in seen:
+                    seen.add(k)
+                    visit.append(k)
+        return visit, frozenset()
+
+    canonical_set = frozenset(order)
+    matched_raw: set[str] = set()
+    for raw in all_raw:
+        for col in order:
+            if raw == col or raw == col.replace("_", "-"):
+                matched_raw.add(raw)
+                break
+
+    extras: list[str] = []
+    seen_extras: set[str] = set()
+    for row in rows:
+        for raw in row.attributes:
+            if raw not in canonical_set and raw not in seen_extras:
+                seen_extras.add(raw)
+                extras.append(raw)
+    return list(order) + extras, canonical_set
+
+
+def _infer_view_type_from_rows(rows: list[ExplorerRow]) -> ExplorerViewType | None:
+    if not rows:
+        return None
+    return _ROW_TYPE_TO_VIEW.get(rows[0].row_type)
+
+
+def _normalize_explorer_csv_column_order(
+    csv_text: str, view_type: ExplorerViewType | None
+) -> str:
+    """Reorder CSV header/data columns to match Explorer API doc order (GET CSV varies)."""
+    if not csv_text.strip() or view_type is None:
+        return csv_text
+    order = _EXPLORER_CSV_COLUMNS.get(view_type)
+    if not order:
+        return csv_text
+    try:
+        reader = csv.reader(io.StringIO(csv_text))
+        rows = list(reader)
+    except csv.Error:
+        return csv_text
+    if not rows or not rows[0]:
+        return csv_text
+    header = rows[0]
+    idx = {name: i for i, name in enumerate(header)}
+    order_set = frozenset(order)
+    canonical = [c for c in order if c in idx]
+    extras = [h for h in header if h not in order_set]
+    new_header = canonical + extras
+    if new_header == header:
+        return csv_text
+    perm = [idx[h] for h in new_header]
+    ncols = len(header)
+    out_rows: list[list[str]] = [new_header]
+    for row in rows[1:]:
+        padded = list(row) + [""] * max(0, ncols - len(row))
+        padded = padded[:ncols]
+        out_rows.append([padded[i] for i in perm])
+    buf = io.StringIO()
+    writer = csv.writer(buf, lineterminator="\n")
+    writer.writerows(out_rows)
+    return buf.getvalue()
+
+
+def _rows_to_csv(
+    rows: list[ExplorerRow],
+    *,
+    view_type: ExplorerViewType | None = None,
+) -> str:
+    """Build CSV from result rows; column order follows Explorer API docs when view_type is known."""
     if not rows:
         return ""
-    keys: set[str] = set()
-    for row in rows:
-        keys.update(row.attributes.keys())
-    fieldnames = sorted(keys)
+    vt = view_type if view_type is not None else _infer_view_type_from_rows(rows)
+    fieldnames, canonical_set = _csv_fieldnames_for_explorer_rows(rows, vt)
     buf = io.StringIO()
     writer = csv.DictWriter(buf, fieldnames=fieldnames, extrasaction="ignore")
     writer.writeheader()
     for row in rows:
-        writer.writerow({k: row.attributes.get(k, "") for k in fieldnames})
+        attrs = row.attributes
+        row_out: dict[str, Any] = {}
+        for name in fieldnames:
+            if name in canonical_set:
+                row_out[name] = _explorer_attribute_value(attrs, name)
+            else:
+                row_out[name] = attrs.get(name, "")
+        writer.writerow(row_out)
     return buf.getvalue()
 
 
@@ -436,7 +607,16 @@ class Explorer(_Service):
         path = f"/api/v2/organizations/{organization}/explorer/views/{view_id}/csv"
         try:
             resp = self.t.request("GET", path)
-            return resp.text
+            csv_text = resp.text
+            try:
+                parsed = list(csv.reader(io.StringIO(csv_text)))
+            except csv.Error:
+                return csv_text
+            if parsed and parsed[0]:
+                vt = _infer_view_type_from_csv_header(parsed[0])
+                if vt is not None:
+                    csv_text = _normalize_explorer_csv_column_order(csv_text, vt)
+            return csv_text
         except (NotFound, ServerError) as exc:
             _log.info(
                 "explorer.saved_view_results_csv: primary CSV route unavailable (%s); "
@@ -447,10 +627,14 @@ class Explorer(_Service):
             )
 
         # Fall back: replay saved definition via export_csv, then row materialization if needed.
+        saved_for_csv: ExplorerSavedView | None = None
         try:
-            saved_view = self.read_saved_view(organization, view_id)
-            options = _query_options_from_saved_view(saved_view)
+            saved_for_csv = self.read_saved_view(organization, view_id)
+            options = _query_options_from_saved_view(saved_for_csv)
             csv_text = self.export_csv(organization, options)
+            csv_text = _normalize_explorer_csv_column_order(
+                csv_text, saved_for_csv.query_type
+            )
             _log.info(
                 "explorer.saved_view_results_csv: used export_csv fallback org=%r view_id=%r",
                 organization,
@@ -466,4 +650,5 @@ class Explorer(_Service):
                 view_id,
             )
             rows = list(self.saved_view_results(organization, view_id))
-            return _rows_to_csv(rows)
+            vt = saved_for_csv.query_type if saved_for_csv is not None else None
+            return _rows_to_csv(rows, view_type=vt)

--- a/src/pytfe/resources/explorer.py
+++ b/src/pytfe/resources/explorer.py
@@ -1,0 +1,469 @@
+# Copyright IBM Corp. 2025, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+"""Explorer API resource.
+
+Maps organization-scoped Explorer endpoints (ad hoc query, CSV export, saved views) to
+typed models. Saved-view create/update reshape filter JSON; read paths normalize API
+variants before validation.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import logging
+from collections.abc import Iterator
+from typing import Any
+
+from ..errors import (
+    InvalidExplorerSavedViewIDError,
+    InvalidOrgError,
+    NotFound,
+    ServerError,
+    ValidationError,
+)
+from ..models.explorer import (
+    ExplorerQueryOptions,
+    ExplorerRow,
+    ExplorerSavedView,
+    ExplorerSavedViewCreateOptions,
+    ExplorerSavedViewUpdateOptions,
+    ExplorerUrlFilter,
+)
+from ..utils import valid_string_id
+from ._base import _Service
+
+_log = logging.getLogger(__name__)
+
+
+def _explorer_single_resource_data(
+    resp: Any,
+    *,
+    operation: str,
+    organization: str,
+    view_id: str | None = None,
+) -> dict[str, Any]:
+    """Parse json:api envelope for a single Explorer saved view; raise ValidationError if unusable."""
+    ctx = f"org={organization!r}"
+    if view_id is not None:
+        ctx += f" view_id={view_id!r}"
+    try:
+        payload = resp.json()
+    except ValueError as exc:
+        _log.warning("explorer.%s: invalid JSON response (%s)", operation, ctx)
+        raise ValidationError(
+            f"Explorer {operation}: response body is not valid JSON ({ctx})"
+        ) from exc
+    if not isinstance(payload, dict):
+        _log.warning(
+            "explorer.%s: top-level JSON is not an object (%s)", operation, ctx
+        )
+        raise ValidationError(
+            f"Explorer {operation}: expected JSON object at top level ({ctx})"
+        )
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        _log.warning(
+            "explorer.%s: missing or invalid 'data' (type=%s) (%s)",
+            operation,
+            type(data).__name__,
+            ctx,
+        )
+        raise ValidationError(
+            f"Explorer {operation}: expected json:api 'data' object ({ctx})"
+        )
+    return data
+
+
+def _require_organization(organization: str) -> None:
+    """Reject blank organization identifiers before building paths."""
+    if not valid_string_id(organization):
+        raise InvalidOrgError()
+
+
+def _require_organization_and_view(organization: str, view_id: str) -> None:
+    """Validate org and saved-view id for routes under .../explorer/views/{view_id}."""
+    _require_organization(organization)
+    if not valid_string_id(view_id):
+        raise InvalidExplorerSavedViewIDError()
+
+
+def _write_attributes_with_query_shape(
+    options: ExplorerSavedViewCreateOptions | ExplorerSavedViewUpdateOptions,
+) -> dict[str, Any]:
+    """Serialize create/update options; map saved-query filters to the map shape POST/PATCH expect."""
+    attrs = options.model_dump(by_alias=True, exclude_none=True, mode="json")
+    raw_query = attrs.get("query")
+    if isinstance(raw_query, dict):
+        attrs["query"] = _saved_query_to_api_shape(raw_query)
+    return attrs
+
+
+def _query_params(options: ExplorerQueryOptions) -> dict[str, Any]:
+    # mode="json" keeps ExplorerViewType as strings; filters are expanded separately (Explorer URL grammar).
+    params = options.model_dump(
+        by_alias=True,
+        exclude_none=True,
+        exclude={"filters"},
+        mode="json",
+    )
+    if options.filters:
+        for flt in options.filters:
+            params[
+                f"filter[{flt.index}][{flt.field}][{flt.operator}][{flt.value_index}]"
+            ] = flt.value
+    return params
+
+
+def _parse_row(item: dict[str, Any]) -> ExplorerRow:
+    return ExplorerRow.model_validate(item)
+
+
+def _saved_query_to_api_shape(raw_query: dict[str, Any]) -> dict[str, Any]:
+    """Map {field, operator, value} filter rows to nested {field: {operator: [...]}} JSON."""
+    query = dict(raw_query)
+    raw_filter = query.get("filter")
+    if isinstance(raw_filter, list):
+        mapped_filters: list[dict[str, Any]] = []
+        for entry in raw_filter:
+            if not isinstance(entry, dict):
+                continue
+            # Already API-compatible map style.
+            if "field" not in entry or "operator" not in entry:
+                mapped_filters.append(entry)
+                continue
+            field = str(entry.get("field", "")).replace("-", "_")
+            operator = str(entry.get("operator", ""))
+            values = entry.get("value", [])
+            if not isinstance(values, list):
+                values = [values]
+            mapped_filters.append({field: {operator: [str(v) for v in values]}})
+        query["filter"] = mapped_filters
+    return query
+
+
+def _normalize_saved_query(
+    raw_query: dict[str, Any], raw_query_type: str | None
+) -> dict[str, Any]:
+    """Coerce saved-view query JSON into the flat filter + list fields shape our models use."""
+    query = dict(raw_query)
+
+    if "type" not in query and raw_query_type:
+        query["type"] = raw_query_type
+
+    raw_filter = query.get("filter")
+    if isinstance(raw_filter, list):
+        normalized_filters: list[dict[str, Any]] = []
+        for entry in raw_filter:
+            # Variant A (documented): {"field": "...", "operator": "...", "value": [...]}
+            if isinstance(entry, dict) and "field" in entry and "operator" in entry:
+                value = entry.get("value")
+                if value is None:
+                    value = []
+                if not isinstance(value, list):
+                    value = [str(value)]
+                normalized_filters.append(
+                    {
+                        "field": str(entry["field"]).replace("-", "_"),
+                        "operator": str(entry["operator"]),
+                        "value": [str(v) for v in value],
+                    }
+                )
+                continue
+
+            # Variant B (observed): {"workspace-name": {"contains": ["foo"]}}
+            if isinstance(entry, dict):
+                for field_name, operators in entry.items():
+                    if not isinstance(operators, dict):
+                        continue
+                    for operator, values in operators.items():
+                        vals = values if isinstance(values, list) else [values]
+                        normalized_filters.append(
+                            {
+                                "field": str(field_name).replace("-", "_"),
+                                "operator": str(operator),
+                                "value": [str(v) for v in vals],
+                            }
+                        )
+        query["filter"] = normalized_filters
+
+    raw_fields = query.get("fields")
+    # Some responses return fields as {"workspaces": [...]}.
+    if isinstance(raw_fields, dict):
+        list_values: list[str] = []
+        for value in raw_fields.values():
+            if isinstance(value, list):
+                list_values.extend(str(v) for v in value)
+        query["fields"] = list_values
+
+    return query
+
+
+def _parse_saved_view(item: dict[str, Any]) -> ExplorerSavedView:
+    # json:api envelope: attributes carry name, timestamps, nested query and query-type.
+    attrs = item.get("attributes", {})
+    query_type = attrs.get("query-type")
+    query = attrs.get("query", {})
+    if not isinstance(query, dict):
+        query = {}
+
+    return ExplorerSavedView.model_validate(
+        {
+            "id": item.get("id"),
+            "name": attrs.get("name"),
+            "created-at": attrs.get("created-at"),
+            "query": _normalize_saved_query(query, query_type),
+            "query-type": query_type,
+        }
+    )
+
+
+def _deleted_saved_view_fallback(view_id: str) -> ExplorerSavedView:
+    """Build a minimal saved view when delete responses have no body."""
+    return ExplorerSavedView.model_validate(
+        {
+            "id": view_id,
+            "name": "",
+            "query-type": "workspaces",
+            "query": {"type": "workspaces"},
+        }
+    )
+
+
+def _query_options_from_saved_view(
+    saved_view: ExplorerSavedView,
+) -> ExplorerQueryOptions:
+    """Replay a stored saved query as GET /explorer query params (used by CSV fallback)."""
+    query = saved_view.query
+    filters: list[ExplorerUrlFilter] = []
+    if query.filter:
+        for idx, flt in enumerate(query.filter):
+            for value_index, value in enumerate(flt.value or []):
+                filters.append(
+                    ExplorerUrlFilter(
+                        index=idx,
+                        field=flt.field,
+                        operator=flt.operator,
+                        value=str(value),
+                        value_index=value_index,
+                    )
+                )
+    return ExplorerQueryOptions.model_validate(
+        {
+            "type": saved_view.query_type,
+            "sort": ",".join(query.sort) if query.sort else None,
+            "fields": ",".join(query.fields) if query.fields else None,
+            "filters": filters or None,
+        }
+    )
+
+
+def _rows_to_csv(rows: list[ExplorerRow]) -> str:
+    """Union of row attribute keys as header; last-resort CSV when /views/.../csv is unavailable."""
+    if not rows:
+        return ""
+    keys: set[str] = set()
+    for row in rows:
+        keys.update(row.attributes.keys())
+    fieldnames = sorted(keys)
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=fieldnames, extrasaction="ignore")
+    writer.writeheader()
+    for row in rows:
+        writer.writerow({k: row.attributes.get(k, "") for k in fieldnames})
+    return buf.getvalue()
+
+
+class Explorer(_Service):
+    """Organization Explorer: ad hoc queries, CSV export, and saved view CRUD."""
+
+    def query(
+        self, organization: str, options: ExplorerQueryOptions
+    ) -> Iterator[ExplorerRow]:
+        _require_organization(organization)
+        _log.debug(
+            "explorer.query org=%r view_type=%s",
+            organization,
+            options.view_type.value,
+        )
+        # GET .../explorer — paginated JSON rows for the given view and filters.
+        path = f"/api/v2/organizations/{organization}/explorer"
+        for item in self._list(path, params=_query_params(options)):
+            yield _parse_row(item)
+
+    def export_csv(self, organization: str, options: ExplorerQueryOptions) -> str:
+        _require_organization(organization)
+        _log.debug(
+            "explorer.export_csv org=%r view_type=%s",
+            organization,
+            options.view_type.value,
+        )
+        # Same query string as query(); response is a single unpaged CSV document.
+        path = f"/api/v2/organizations/{organization}/explorer/export/csv"
+        resp = self.t.request("GET", path, params=_query_params(options))
+        return resp.text
+
+    def list_saved_views(self, organization: str) -> Iterator[ExplorerSavedView]:
+        _require_organization(organization)
+        _log.debug("explorer.list_saved_views org=%r", organization)
+        # GET collection of explorer-saved-queries for the org.
+        path = f"/api/v2/organizations/{organization}/explorer/views"
+        for item in self._list(path):
+            yield _parse_saved_view(item)
+
+    def create_saved_view(
+        self, organization: str, options: ExplorerSavedViewCreateOptions
+    ) -> ExplorerSavedView:
+        _require_organization(organization)
+        # POST json:api explorer-saved-queries; filters rewritten for server expectations.
+        attrs = _write_attributes_with_query_shape(options)
+        body = {
+            "data": {
+                "type": "explorer-saved-queries",
+                "attributes": attrs,
+            }
+        }
+        path = f"/api/v2/organizations/{organization}/explorer/views"
+        resp = self.t.request("POST", path, json_body=body)
+        data = _explorer_single_resource_data(
+            resp, operation="create_saved_view", organization=organization
+        )
+        view = _parse_saved_view(data)
+        _log.info("explorer.create_saved_view org=%r id=%r", organization, view.id)
+        return view
+
+    def read_saved_view(self, organization: str, view_id: str) -> ExplorerSavedView:
+        _require_organization_and_view(organization, view_id)
+        _log.debug(
+            "explorer.read_saved_view org=%r view_id=%r",
+            organization,
+            view_id,
+        )
+        # Returns stored definition only; does not execute the query (see saved_view_results).
+        path = f"/api/v2/organizations/{organization}/explorer/views/{view_id}"
+        resp = self.t.request("GET", path)
+        data = _explorer_single_resource_data(
+            resp,
+            operation="read_saved_view",
+            organization=organization,
+            view_id=view_id,
+        )
+        return _parse_saved_view(data)
+
+    def update_saved_view(
+        self,
+        organization: str,
+        view_id: str,
+        options: ExplorerSavedViewUpdateOptions,
+    ) -> ExplorerSavedView:
+        _require_organization_and_view(organization, view_id)
+        attrs = _write_attributes_with_query_shape(options)
+        # PATCH includes resource id in the envelope per json:api update conventions.
+        body = {
+            "data": {
+                "type": "explorer-saved-queries",
+                "id": view_id,
+                "attributes": attrs,
+            }
+        }
+        path = f"/api/v2/organizations/{organization}/explorer/views/{view_id}"
+        resp = self.t.request("PATCH", path, json_body=body)
+        data = _explorer_single_resource_data(
+            resp,
+            operation="update_saved_view",
+            organization=organization,
+            view_id=view_id,
+        )
+        view = _parse_saved_view(data)
+        _log.info("explorer.update_saved_view org=%r id=%r", organization, view.id)
+        return view
+
+    def delete_saved_view(self, organization: str, view_id: str) -> ExplorerSavedView:
+        _require_organization_and_view(organization, view_id)
+        path = f"/api/v2/organizations/{organization}/explorer/views/{view_id}"
+        resp = self.t.request("DELETE", path)
+        # DELETE often returns an empty body; callers still receive a minimal ExplorerSavedView.
+        raw_text = (resp.text or "").strip()
+        if not raw_text:
+            _log.debug(
+                "explorer.delete_saved_view: empty body, returning stub org=%r id=%r",
+                organization,
+                view_id,
+            )
+            return _deleted_saved_view_fallback(view_id)
+
+        try:
+            payload = resp.json()
+        except ValueError:
+            _log.debug(
+                "explorer.delete_saved_view: non-JSON body, returning stub org=%r id=%r",
+                organization,
+                view_id,
+            )
+            return _deleted_saved_view_fallback(view_id)
+
+        if isinstance(payload, dict) and isinstance(payload.get("data"), dict):
+            return _parse_saved_view(payload["data"])
+        _log.debug(
+            "explorer.delete_saved_view: no data object, returning stub org=%r id=%r",
+            organization,
+            view_id,
+        )
+        return _deleted_saved_view_fallback(view_id)
+
+    def saved_view_results(
+        self, organization: str, view_id: str
+    ) -> Iterator[ExplorerRow]:
+        _require_organization_and_view(organization, view_id)
+        _log.debug(
+            "explorer.saved_view_results org=%r view_id=%r",
+            organization,
+            view_id,
+        )
+        # Re-runs the saved query; rows match ad hoc query() shape (current data only).
+        path = f"/api/v2/organizations/{organization}/explorer/views/{view_id}/results"
+        for item in self._list(path):
+            yield _parse_row(item)
+
+    def saved_view_results_csv(self, organization: str, view_id: str) -> str:
+        _require_organization_and_view(organization, view_id)
+        _log.debug(
+            "explorer.saved_view_results_csv org=%r view_id=%r",
+            organization,
+            view_id,
+        )
+        path = f"/api/v2/organizations/{organization}/explorer/views/{view_id}/csv"
+        try:
+            resp = self.t.request("GET", path)
+            return resp.text
+        except (NotFound, ServerError) as exc:
+            _log.info(
+                "explorer.saved_view_results_csv: primary CSV route unavailable (%s); "
+                "trying export_csv replay org=%r view_id=%r",
+                exc.__class__.__name__,
+                organization,
+                view_id,
+            )
+
+        # Fall back: replay saved definition via export_csv, then row materialization if needed.
+        try:
+            saved_view = self.read_saved_view(organization, view_id)
+            options = _query_options_from_saved_view(saved_view)
+            csv_text = self.export_csv(organization, options)
+            _log.info(
+                "explorer.saved_view_results_csv: used export_csv fallback org=%r view_id=%r",
+                organization,
+                view_id,
+            )
+            return csv_text
+        except (NotFound, ServerError) as exc:
+            _log.warning(
+                "explorer.saved_view_results_csv: export_csv fallback failed (%s); "
+                "building CSV from row stream org=%r view_id=%r",
+                exc.__class__.__name__,
+                organization,
+                view_id,
+            )
+            rows = list(self.saved_view_results(organization, view_id))
+            return _rows_to_csv(rows)

--- a/tests/units/test_explorer.py
+++ b/tests/units/test_explorer.py
@@ -1,0 +1,387 @@
+# Copyright IBM Corp. 2025, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+"""Unit tests for Explorer API resource."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from pytfe.errors import (
+    InvalidExplorerSavedViewIDError,
+    InvalidOrgError,
+    NotFound,
+    ValidationError,
+)
+from pytfe.models import (
+    ExplorerQueryOptions,
+    ExplorerSavedQuery,
+    ExplorerSavedQueryFilter,
+    ExplorerSavedViewCreateOptions,
+    ExplorerSavedViewUpdateOptions,
+    ExplorerUrlFilter,
+    ExplorerViewType,
+)
+from pytfe.resources.explorer import Explorer
+
+
+@pytest.fixture
+def mock_transport():
+    return Mock()
+
+
+@pytest.fixture
+def explorer_service(mock_transport):
+    return Explorer(mock_transport)
+
+
+def _row_payload(row_id: str) -> dict:
+    return {
+        "id": row_id,
+        "type": "visibility-workspace",
+        "attributes": {"workspace-name": "demo-workspace"},
+    }
+
+
+def _saved_view_payload(view_id: str) -> dict:
+    return {
+        "id": view_id,
+        "type": "explorer-saved-queries",
+        "attributes": {
+            "name": "my-view",
+            "created-at": "2024-10-11T16:18:51.442Z",
+            "query-type": "workspaces",
+            "query": {
+                "type": "workspaces",
+                "filter": [
+                    {
+                        "field": "workspace_name",
+                        "operator": "contains",
+                        "value": ["child"],
+                    }
+                ],
+            },
+        },
+    }
+
+
+def _saved_view_payload_live_variant(view_id: str) -> dict:
+    return {
+        "id": view_id,
+        "type": "explorer-saved-queries",
+        "attributes": {
+            "name": "my-view",
+            "created-at": "2024-10-11T16:18:51.442Z",
+            "query-type": "workspaces",
+            "query": {
+                "filter": [{"workspace-name": {"contains": ["r2l7cj4v"]}}],
+                "fields": {"workspaces": []},
+            },
+        },
+    }
+
+
+class TestExplorerQuery:
+    def test_query_with_filter_and_pagination(self, explorer_service, mock_transport):
+        first = Mock()
+        first.json.return_value = {"data": [_row_payload("ws-1")]}
+        second = Mock()
+        second.json.return_value = {"data": []}
+        mock_transport.request.side_effect = [first, second]
+
+        options = ExplorerQueryOptions(
+            view_type=ExplorerViewType.WORKSPACES,
+            sort="-workspace_name",
+            fields="workspace_name,organization_name",
+            page_size=1,
+            filters=[
+                ExplorerUrlFilter(
+                    index=0,
+                    field="workspace_name",
+                    operator="contains",
+                    value="test",
+                )
+            ],
+        )
+
+        rows = list(explorer_service.query("acme", options))
+        assert len(rows) == 1
+        assert rows[0].id == "ws-1"
+        assert rows[0].row_type == "visibility-workspace"
+
+        first_call = mock_transport.request.call_args_list[0]
+        assert first_call[0][0] == "GET"
+        assert first_call[0][1] == "/api/v2/organizations/acme/explorer"
+        params = first_call[1]["params"]
+        assert params["type"] == "workspaces"
+        assert params["sort"] == "-workspace_name"
+        assert params["fields"] == "workspace_name,organization_name"
+        assert params["page[size]"] == 1
+        assert params["filter[0][workspace_name][contains][0]"] == "test"
+
+    def test_query_invalid_org(self, explorer_service):
+        with pytest.raises(InvalidOrgError):
+            list(
+                explorer_service.query(
+                    "",
+                    ExplorerQueryOptions(view_type=ExplorerViewType.WORKSPACES),
+                )
+            )
+
+    def test_export_csv(self, explorer_service, mock_transport):
+        response = Mock()
+        response.text = "workspace_name\nexample\n"
+        mock_transport.request.return_value = response
+
+        csv_text = explorer_service.export_csv(
+            "acme", ExplorerQueryOptions(view_type=ExplorerViewType.WORKSPACES)
+        )
+
+        assert "workspace_name" in csv_text
+        mock_transport.request.assert_called_once_with(
+            "GET",
+            "/api/v2/organizations/acme/explorer/export/csv",
+            params={"type": "workspaces"},
+        )
+
+
+class TestExplorerSavedViews:
+    def test_list_saved_views(self, explorer_service, mock_transport):
+        response = Mock()
+        response.json.return_value = {"data": [_saved_view_payload("sq-1")]}
+        mock_transport.request.return_value = response
+
+        views = list(explorer_service.list_saved_views("acme"))
+        assert len(views) == 1
+        assert views[0].id == "sq-1"
+        assert views[0].query_type == ExplorerViewType.WORKSPACES
+        assert views[0].query.query_type == ExplorerViewType.WORKSPACES
+
+    def test_create_saved_view(self, explorer_service, mock_transport):
+        response = Mock()
+        response.json.return_value = {"data": _saved_view_payload("sq-new")}
+        mock_transport.request.return_value = response
+
+        options = ExplorerSavedViewCreateOptions(
+            name="my-view",
+            query_type=ExplorerViewType.WORKSPACES,
+            query=ExplorerSavedQuery(
+                query_type=ExplorerViewType.WORKSPACES,
+                filter=[
+                    ExplorerSavedQueryFilter(
+                        field="workspace_name", operator="contains", value=["test"]
+                    )
+                ],
+            ),
+        )
+        view = explorer_service.create_saved_view("acme", options)
+
+        assert view.id == "sq-new"
+        call = mock_transport.request.call_args
+        assert call[0][0] == "POST"
+        assert call[0][1] == "/api/v2/organizations/acme/explorer/views"
+        body = call[1]["json_body"]
+        assert body["data"]["type"] == "explorer-saved-queries"
+        assert body["data"]["attributes"]["query-type"] == "workspaces"
+        assert body["data"]["attributes"]["query"]["filter"] == [
+            {"workspace_name": {"contains": ["test"]}}
+        ]
+
+    def test_create_saved_view_invalid_json_raises(
+        self, explorer_service, mock_transport
+    ):
+        response = Mock()
+        response.json.side_effect = ValueError("invalid json")
+        mock_transport.request.return_value = response
+
+        options = ExplorerSavedViewCreateOptions(
+            name="my-view",
+            query_type=ExplorerViewType.WORKSPACES,
+            query=ExplorerSavedQuery(query_type=ExplorerViewType.WORKSPACES),
+        )
+        with pytest.raises(ValidationError, match="create_saved_view"):
+            explorer_service.create_saved_view("acme", options)
+
+    def test_read_saved_view_missing_data_object_raises(
+        self, explorer_service, mock_transport
+    ):
+        response = Mock()
+        response.json.return_value = {"data": []}
+        mock_transport.request.return_value = response
+
+        with pytest.raises(ValidationError, match="read_saved_view"):
+            explorer_service.read_saved_view("acme", "sq-1")
+
+    def test_read_saved_view(self, explorer_service, mock_transport):
+        response = Mock()
+        response.json.return_value = {"data": _saved_view_payload("sq-1")}
+        mock_transport.request.return_value = response
+
+        view = explorer_service.read_saved_view("acme", "sq-1")
+        assert view.id == "sq-1"
+
+        mock_transport.request.assert_called_once_with(
+            "GET", "/api/v2/organizations/acme/explorer/views/sq-1"
+        )
+
+    def test_read_saved_view_with_live_query_shape(
+        self, explorer_service, mock_transport
+    ):
+        response = Mock()
+        response.json.return_value = {"data": _saved_view_payload_live_variant("sq-2")}
+        mock_transport.request.return_value = response
+
+        view = explorer_service.read_saved_view("acme", "sq-2")
+
+        assert view.id == "sq-2"
+        assert view.query.query_type == ExplorerViewType.WORKSPACES
+        assert view.query.filter is not None
+        assert view.query.filter[0].field == "workspace_name"
+        assert view.query.filter[0].operator == "contains"
+        assert view.query.filter[0].value == ["r2l7cj4v"]
+        assert view.query.fields == []
+
+    def test_update_saved_view(self, explorer_service, mock_transport):
+        response = Mock()
+        response.json.return_value = {"data": _saved_view_payload("sq-1")}
+        mock_transport.request.return_value = response
+
+        options = ExplorerSavedViewUpdateOptions(
+            name="my-view-updated",
+            query=ExplorerSavedQuery(
+                query_type=ExplorerViewType.WORKSPACES,
+                filter=[
+                    ExplorerSavedQueryFilter(
+                        field="workspace_name", operator="contains", value=["prod"]
+                    )
+                ],
+            ),
+        )
+        view = explorer_service.update_saved_view("acme", "sq-1", options)
+
+        assert view.id == "sq-1"
+        call = mock_transport.request.call_args
+        assert call[0][0] == "PATCH"
+        assert call[0][1] == "/api/v2/organizations/acme/explorer/views/sq-1"
+        assert call[1]["json_body"]["data"]["id"] == "sq-1"
+        assert call[1]["json_body"]["data"]["attributes"]["name"] == "my-view-updated"
+        assert call[1]["json_body"]["data"]["attributes"]["query"]["filter"] == [
+            {"workspace_name": {"contains": ["prod"]}}
+        ]
+
+    def test_delete_saved_view(self, explorer_service, mock_transport):
+        response = Mock()
+        response.json.return_value = {"data": _saved_view_payload("sq-1")}
+        response.text = '{"data":{"id":"sq-1"}}'
+        mock_transport.request.return_value = response
+
+        view = explorer_service.delete_saved_view("acme", "sq-1")
+        assert view.id == "sq-1"
+
+        mock_transport.request.assert_called_once_with(
+            "DELETE", "/api/v2/organizations/acme/explorer/views/sq-1"
+        )
+
+    def test_delete_saved_view_empty_response(self, explorer_service, mock_transport):
+        response = Mock()
+        response.text = ""
+        response.json.side_effect = ValueError("No JSON body")
+        mock_transport.request.return_value = response
+
+        view = explorer_service.delete_saved_view("acme", "sq-1")
+        assert view.id == "sq-1"
+
+    def test_saved_view_results(self, explorer_service, mock_transport):
+        first = Mock()
+        first.json.return_value = {"data": [_row_payload("ws-1")]}
+        second = Mock()
+        second.json.return_value = {"data": []}
+        mock_transport.request.side_effect = [first, second]
+
+        rows = list(explorer_service.saved_view_results("acme", "sq-1"))
+        assert len(rows) == 1
+        assert rows[0].id == "ws-1"
+
+        mock_transport.request.assert_any_call(
+            "GET",
+            "/api/v2/organizations/acme/explorer/views/sq-1/results",
+            params={"page[number]": 1, "page[size]": 100},
+        )
+
+    def test_saved_view_results_csv(self, explorer_service, mock_transport):
+        response = Mock()
+        response.text = "workspace_name\nexample\n"
+        mock_transport.request.return_value = response
+
+        csv_text = explorer_service.saved_view_results_csv("acme", "sq-1")
+        assert "workspace_name" in csv_text
+        mock_transport.request.assert_called_once_with(
+            "GET", "/api/v2/organizations/acme/explorer/views/sq-1/csv"
+        )
+
+    def test_saved_view_results_csv_fallback_to_export(
+        self, explorer_service, mock_transport
+    ):
+        first = NotFound("not found", status=404)
+        read_resp = Mock()
+        read_resp.json.return_value = {"data": _saved_view_payload("sq-1")}
+        export_resp = Mock()
+        export_resp.text = "workspace_name\nfrom-export\n"
+        mock_transport.request.side_effect = [first, read_resp, export_resp]
+
+        csv_text = explorer_service.saved_view_results_csv("acme", "sq-1")
+        assert "from-export" in csv_text
+
+    def test_saved_view_results_csv_fallback_to_rows(
+        self, explorer_service, mock_transport
+    ):
+        not_found = NotFound("not found", status=404)
+        read_resp = Mock()
+        read_resp.json.return_value = {"data": _saved_view_payload("sq-1")}
+        first_results = Mock()
+        first_results.json.return_value = {"data": [_row_payload("ws-1")]}
+        second_results = Mock()
+        second_results.json.return_value = {"data": []}
+        mock_transport.request.side_effect = [
+            not_found,  # /csv
+            read_resp,  # read saved view
+            not_found,  # export_csv fallback fails
+            first_results,  # saved_view_results page 1
+            second_results,  # saved_view_results page 2
+        ]
+
+        csv_text = explorer_service.saved_view_results_csv("acme", "sq-1")
+        assert "workspace-name" in csv_text
+        assert "demo-workspace" in csv_text
+
+    @pytest.mark.parametrize("org", ["", None])
+    def test_saved_view_methods_invalid_org(self, explorer_service, org):
+        with pytest.raises(InvalidOrgError):
+            list(explorer_service.list_saved_views(org))
+
+        with pytest.raises(InvalidOrgError):
+            explorer_service.read_saved_view(org, "sq-1")
+
+    @pytest.mark.parametrize("view_id", ["", None])
+    def test_saved_view_methods_invalid_id(self, explorer_service, view_id):
+        with pytest.raises(InvalidExplorerSavedViewIDError):
+            explorer_service.read_saved_view("acme", view_id)
+
+        with pytest.raises(InvalidExplorerSavedViewIDError):
+            explorer_service.update_saved_view(
+                "acme",
+                view_id,
+                ExplorerSavedViewUpdateOptions(
+                    name="updated",
+                    query=ExplorerSavedQuery(query_type=ExplorerViewType.WORKSPACES),
+                ),
+            )
+
+        with pytest.raises(InvalidExplorerSavedViewIDError):
+            explorer_service.delete_saved_view("acme", view_id)
+
+        with pytest.raises(InvalidExplorerSavedViewIDError):
+            list(explorer_service.saved_view_results("acme", view_id))
+
+        with pytest.raises(InvalidExplorerSavedViewIDError):
+            explorer_service.saved_view_results_csv("acme", view_id)

--- a/tests/units/test_explorer.py
+++ b/tests/units/test_explorer.py
@@ -15,6 +15,7 @@ from pytfe.errors import (
 )
 from pytfe.models import (
     ExplorerQueryOptions,
+    ExplorerRow,
     ExplorerSavedQuery,
     ExplorerSavedQueryFilter,
     ExplorerSavedViewCreateOptions,
@@ -22,7 +23,11 @@ from pytfe.models import (
     ExplorerUrlFilter,
     ExplorerViewType,
 )
-from pytfe.resources.explorer import Explorer
+from pytfe.resources.explorer import (
+    Explorer,
+    _normalize_explorer_csv_column_order,
+    _rows_to_csv,
+)
 
 
 @pytest.fixture
@@ -33,6 +38,36 @@ def mock_transport():
 @pytest.fixture
 def explorer_service(mock_transport):
     return Explorer(mock_transport)
+
+
+def test_normalize_explorer_csv_column_order_workspaces():
+    raw = "workspace_name,all_checks_succeeded\ndemo,true\n"
+    out = _normalize_explorer_csv_column_order(raw, ExplorerViewType.WORKSPACES)
+    assert out.splitlines()[0].startswith("all_checks_succeeded,workspace_name")
+
+
+def test_rows_to_csv_workspace_column_order_matches_doc():
+    """Fallback CSV header matches Explorer export/csv workspaces sample column order."""
+    rows = [
+        ExplorerRow.model_validate(
+            {
+                "id": "ws-1",
+                "type": "visibility-workspace",
+                "attributes": {"workspace-name": "demo-workspace"},
+            }
+        )
+    ]
+    csv_text = _rows_to_csv(rows, view_type=ExplorerViewType.WORKSPACES)
+    header = csv_text.strip().splitlines()[0]
+    assert header.startswith(
+        "all_checks_succeeded,current_rum_count,checks_errored,checks_failed,"
+        "checks_passed,checks_unknown,current_run_applied_at,current_run_external_id,"
+        "current_run_status,drifted,external_id,module_count,modules,organization_name,"
+        "project_external_id,project_name,provider_count,providers,resources_drifted,"
+        "resources_undrifted,state_version_terraform_version,vcs_repo_identifier,"
+        "workspace_created_at,workspace_name,workspace_terraform_version,workspace_updated_at"
+    )
+    assert "demo-workspace" in csv_text
 
 
 def _row_payload(row_id: str) -> dict:
@@ -309,12 +344,14 @@ class TestExplorerSavedViews:
         )
 
     def test_saved_view_results_csv(self, explorer_service, mock_transport):
-        response = Mock()
-        response.text = "workspace_name\nexample\n"
-        mock_transport.request.return_value = response
+        csv_resp = Mock()
+        csv_resp.text = "workspace_name,all_checks_succeeded\ndemo,true\n"
+        mock_transport.request.return_value = csv_resp
 
         csv_text = explorer_service.saved_view_results_csv("acme", "sq-1")
-        assert "workspace_name" in csv_text
+        assert csv_text.splitlines()[0].startswith(
+            "all_checks_succeeded,workspace_name"
+        )
         mock_transport.request.assert_called_once_with(
             "GET", "/api/v2/organizations/acme/explorer/views/sq-1/csv"
         )
@@ -351,7 +388,15 @@ class TestExplorerSavedViews:
         ]
 
         csv_text = explorer_service.saved_view_results_csv("acme", "sq-1")
-        assert "workspace-name" in csv_text
+        header = csv_text.strip().splitlines()[0]
+        assert header.startswith(
+            "all_checks_succeeded,current_rum_count,checks_errored,checks_failed,"
+            "checks_passed,checks_unknown,current_run_applied_at,current_run_external_id,"
+            "current_run_status,drifted,external_id,module_count,modules,organization_name,"
+            "project_external_id,project_name,provider_count,providers,resources_drifted,"
+            "resources_undrifted,state_version_terraform_version,vcs_repo_identifier,"
+            "workspace_created_at,workspace_name,workspace_terraform_version,workspace_updated_at"
+        )
         assert "demo-workspace" in csv_text
 
     @pytest.mark.parametrize("org", ["", None])

--- a/tests/units/test_explorer.py
+++ b/tests/units/test_explorer.py
@@ -3,7 +3,8 @@
 
 """Unit tests for Explorer API resource."""
 
-from unittest.mock import Mock
+import csv
+from unittest.mock import Mock, call
 
 import pytest
 
@@ -11,6 +12,7 @@ from pytfe.errors import (
     InvalidExplorerSavedViewIDError,
     InvalidOrgError,
     NotFound,
+    ServerError,
     ValidationError,
 )
 from pytfe.models import (
@@ -28,6 +30,11 @@ from pytfe.resources.explorer import (
     _normalize_explorer_csv_column_order,
     _rows_to_csv,
 )
+
+ORG = "acme"
+VIEW_ID = "sq-1"
+EXPLORER_PATH = f"/api/v2/organizations/{ORG}/explorer"
+VIEWS_PATH = f"{EXPLORER_PATH}/views"
 
 
 @pytest.fixture
@@ -116,13 +123,34 @@ def _saved_view_payload_live_variant(view_id: str) -> dict:
     }
 
 
+def _assert_single_request_call(
+    mock_transport, method: str, path: str, **kwargs
+) -> None:
+    mock_transport.request.assert_called_once_with(method, path, **kwargs)
+
+
+def _query_request_params(page_number: int) -> dict:
+    return {
+        "type": "workspaces",
+        "sort": "-workspace_name",
+        "fields": "workspace_name,organization_name",
+        "page[size]": 1,
+        "filter[0][workspace_name][contains][0]": "test",
+        "page[number]": page_number,
+    }
+
+
 class TestExplorerQuery:
     def test_query_with_filter_and_pagination(self, explorer_service, mock_transport):
         first = Mock()
         first.json.return_value = {"data": [_row_payload("ws-1")]}
         second = Mock()
-        second.json.return_value = {"data": []}
-        mock_transport.request.side_effect = [first, second]
+        second.json.return_value = {"data": [_row_payload("ws-2")]}
+        third = Mock()
+        third.json.return_value = {"data": [_row_payload("ws-3")]}
+        fourth = Mock()
+        fourth.json.return_value = {"data": []}
+        mock_transport.request.side_effect = [first, second, third, fourth]
 
         options = ExplorerQueryOptions(
             view_type=ExplorerViewType.WORKSPACES,
@@ -139,20 +167,19 @@ class TestExplorerQuery:
             ],
         )
 
-        rows = list(explorer_service.query("acme", options))
-        assert len(rows) == 1
-        assert rows[0].id == "ws-1"
-        assert rows[0].row_type == "visibility-workspace"
+        rows = list(explorer_service.query(ORG, options))
+        assert len(rows) == 3
+        assert [row.id for row in rows] == ["ws-1", "ws-2", "ws-3"]
+        assert all(row.row_type == "visibility-workspace" for row in rows)
 
-        first_call = mock_transport.request.call_args_list[0]
-        assert first_call[0][0] == "GET"
-        assert first_call[0][1] == "/api/v2/organizations/acme/explorer"
-        params = first_call[1]["params"]
-        assert params["type"] == "workspaces"
-        assert params["sort"] == "-workspace_name"
-        assert params["fields"] == "workspace_name,organization_name"
-        assert params["page[size]"] == 1
-        assert params["filter[0][workspace_name][contains][0]"] == "test"
+        expected_calls = [
+            call("GET", EXPLORER_PATH, params=_query_request_params(page_number=1)),
+            call("GET", EXPLORER_PATH, params=_query_request_params(page_number=2)),
+            call("GET", EXPLORER_PATH, params=_query_request_params(page_number=3)),
+            call("GET", EXPLORER_PATH, params=_query_request_params(page_number=4)),
+        ]
+        mock_transport.request.assert_has_calls(expected_calls)
+        assert mock_transport.request.call_count == 4
 
     def test_query_invalid_org(self, explorer_service):
         with pytest.raises(InvalidOrgError):
@@ -163,19 +190,28 @@ class TestExplorerQuery:
                 )
             )
 
+    @pytest.mark.parametrize("org", ["", None])
+    def test_export_csv_invalid_org(self, explorer_service, org):
+        with pytest.raises(InvalidOrgError):
+            explorer_service.export_csv(
+                org,
+                ExplorerQueryOptions(view_type=ExplorerViewType.WORKSPACES),
+            )
+
     def test_export_csv(self, explorer_service, mock_transport):
         response = Mock()
         response.text = "workspace_name\nexample\n"
         mock_transport.request.return_value = response
 
         csv_text = explorer_service.export_csv(
-            "acme", ExplorerQueryOptions(view_type=ExplorerViewType.WORKSPACES)
+            ORG, ExplorerQueryOptions(view_type=ExplorerViewType.WORKSPACES)
         )
 
         assert "workspace_name" in csv_text
-        mock_transport.request.assert_called_once_with(
+        _assert_single_request_call(
+            mock_transport,
             "GET",
-            "/api/v2/organizations/acme/explorer/export/csv",
+            f"{EXPLORER_PATH}/export/csv",
             params={"type": "workspaces"},
         )
 
@@ -186,7 +222,7 @@ class TestExplorerSavedViews:
         response.json.return_value = {"data": [_saved_view_payload("sq-1")]}
         mock_transport.request.return_value = response
 
-        views = list(explorer_service.list_saved_views("acme"))
+        views = list(explorer_service.list_saved_views(ORG))
         assert len(views) == 1
         assert views[0].id == "sq-1"
         assert views[0].query_type == ExplorerViewType.WORKSPACES
@@ -209,12 +245,12 @@ class TestExplorerSavedViews:
                 ],
             ),
         )
-        view = explorer_service.create_saved_view("acme", options)
+        view = explorer_service.create_saved_view(ORG, options)
 
         assert view.id == "sq-new"
         call = mock_transport.request.call_args
         assert call[0][0] == "POST"
-        assert call[0][1] == "/api/v2/organizations/acme/explorer/views"
+        assert call[0][1] == VIEWS_PATH
         body = call[1]["json_body"]
         assert body["data"]["type"] == "explorer-saved-queries"
         assert body["data"]["attributes"]["query-type"] == "workspaces"
@@ -235,7 +271,7 @@ class TestExplorerSavedViews:
             query=ExplorerSavedQuery(query_type=ExplorerViewType.WORKSPACES),
         )
         with pytest.raises(ValidationError, match="create_saved_view"):
-            explorer_service.create_saved_view("acme", options)
+            explorer_service.create_saved_view(ORG, options)
 
     def test_read_saved_view_missing_data_object_raises(
         self, explorer_service, mock_transport
@@ -245,19 +281,17 @@ class TestExplorerSavedViews:
         mock_transport.request.return_value = response
 
         with pytest.raises(ValidationError, match="read_saved_view"):
-            explorer_service.read_saved_view("acme", "sq-1")
+            explorer_service.read_saved_view(ORG, VIEW_ID)
 
     def test_read_saved_view(self, explorer_service, mock_transport):
         response = Mock()
         response.json.return_value = {"data": _saved_view_payload("sq-1")}
         mock_transport.request.return_value = response
 
-        view = explorer_service.read_saved_view("acme", "sq-1")
+        view = explorer_service.read_saved_view(ORG, VIEW_ID)
         assert view.id == "sq-1"
 
-        mock_transport.request.assert_called_once_with(
-            "GET", "/api/v2/organizations/acme/explorer/views/sq-1"
-        )
+        _assert_single_request_call(mock_transport, "GET", f"{VIEWS_PATH}/{VIEW_ID}")
 
     def test_read_saved_view_with_live_query_shape(
         self, explorer_service, mock_transport
@@ -266,7 +300,7 @@ class TestExplorerSavedViews:
         response.json.return_value = {"data": _saved_view_payload_live_variant("sq-2")}
         mock_transport.request.return_value = response
 
-        view = explorer_service.read_saved_view("acme", "sq-2")
+        view = explorer_service.read_saved_view(ORG, "sq-2")
 
         assert view.id == "sq-2"
         assert view.query.query_type == ExplorerViewType.WORKSPACES
@@ -292,17 +326,57 @@ class TestExplorerSavedViews:
                 ],
             ),
         )
-        view = explorer_service.update_saved_view("acme", "sq-1", options)
+        view = explorer_service.update_saved_view(ORG, VIEW_ID, options)
 
         assert view.id == "sq-1"
-        call = mock_transport.request.call_args
-        assert call[0][0] == "PATCH"
-        assert call[0][1] == "/api/v2/organizations/acme/explorer/views/sq-1"
-        assert call[1]["json_body"]["data"]["id"] == "sq-1"
-        assert call[1]["json_body"]["data"]["attributes"]["name"] == "my-view-updated"
-        assert call[1]["json_body"]["data"]["attributes"]["query"]["filter"] == [
-            {"workspace_name": {"contains": ["prod"]}}
-        ]
+        expected_body = {
+            "data": {
+                "type": "explorer-saved-queries",
+                "id": VIEW_ID,
+                "attributes": {
+                    "name": "my-view-updated",
+                    "query": {
+                        "type": "workspaces",
+                        "filter": [{"workspace_name": {"contains": ["prod"]}}],
+                    },
+                },
+            }
+        }
+        _assert_single_request_call(
+            mock_transport,
+            "PATCH",
+            f"{VIEWS_PATH}/{VIEW_ID}",
+            json_body=expected_body,
+        )
+
+    def test_update_saved_view_invalid_json_raises(
+        self, explorer_service, mock_transport
+    ):
+        response = Mock()
+        response.json.side_effect = ValueError("invalid json")
+        mock_transport.request.return_value = response
+
+        options = ExplorerSavedViewUpdateOptions(
+            name="my-view-updated",
+            query=ExplorerSavedQuery(query_type=ExplorerViewType.WORKSPACES),
+        )
+        with pytest.raises(ValidationError, match="update_saved_view"):
+            explorer_service.update_saved_view(ORG, VIEW_ID, options)
+
+    @pytest.mark.parametrize("payload", [[], "bad-payload", {"data": []}])
+    def test_update_saved_view_invalid_data_shape_raises(
+        self, explorer_service, mock_transport, payload
+    ):
+        response = Mock()
+        response.json.return_value = payload
+        mock_transport.request.return_value = response
+
+        options = ExplorerSavedViewUpdateOptions(
+            name="my-view-updated",
+            query=ExplorerSavedQuery(query_type=ExplorerViewType.WORKSPACES),
+        )
+        with pytest.raises(ValidationError, match="update_saved_view"):
+            explorer_service.update_saved_view(ORG, VIEW_ID, options)
 
     def test_delete_saved_view(self, explorer_service, mock_transport):
         response = Mock()
@@ -310,12 +384,10 @@ class TestExplorerSavedViews:
         response.text = '{"data":{"id":"sq-1"}}'
         mock_transport.request.return_value = response
 
-        view = explorer_service.delete_saved_view("acme", "sq-1")
+        view = explorer_service.delete_saved_view(ORG, VIEW_ID)
         assert view.id == "sq-1"
 
-        mock_transport.request.assert_called_once_with(
-            "DELETE", "/api/v2/organizations/acme/explorer/views/sq-1"
-        )
+        _assert_single_request_call(mock_transport, "DELETE", f"{VIEWS_PATH}/{VIEW_ID}")
 
     def test_delete_saved_view_empty_response(self, explorer_service, mock_transport):
         response = Mock()
@@ -323,8 +395,34 @@ class TestExplorerSavedViews:
         response.json.side_effect = ValueError("No JSON body")
         mock_transport.request.return_value = response
 
-        view = explorer_service.delete_saved_view("acme", "sq-1")
+        view = explorer_service.delete_saved_view(ORG, VIEW_ID)
         assert view.id == "sq-1"
+
+    def test_delete_saved_view_non_json_body_returns_stub(
+        self, explorer_service, mock_transport
+    ):
+        response = Mock()
+        response.text = "deleted"
+        response.json.side_effect = ValueError("No JSON body")
+        mock_transport.request.return_value = response
+
+        view = explorer_service.delete_saved_view(ORG, VIEW_ID)
+        assert view.id == "sq-1"
+        assert view.name == ""
+        assert view.query_type == ExplorerViewType.WORKSPACES
+
+    def test_delete_saved_view_invalid_data_shape_returns_stub(
+        self, explorer_service, mock_transport
+    ):
+        response = Mock()
+        response.text = '{"data":[]}'
+        response.json.return_value = {"data": []}
+        mock_transport.request.return_value = response
+
+        view = explorer_service.delete_saved_view(ORG, VIEW_ID)
+        assert view.id == "sq-1"
+        assert view.name == ""
+        assert view.query_type == ExplorerViewType.WORKSPACES
 
     def test_saved_view_results(self, explorer_service, mock_transport):
         first = Mock()
@@ -333,13 +431,13 @@ class TestExplorerSavedViews:
         second.json.return_value = {"data": []}
         mock_transport.request.side_effect = [first, second]
 
-        rows = list(explorer_service.saved_view_results("acme", "sq-1"))
+        rows = list(explorer_service.saved_view_results(ORG, VIEW_ID))
         assert len(rows) == 1
         assert rows[0].id == "ws-1"
 
         mock_transport.request.assert_any_call(
             "GET",
-            "/api/v2/organizations/acme/explorer/views/sq-1/results",
+            f"{VIEWS_PATH}/{VIEW_ID}/results",
             params={"page[number]": 1, "page[size]": 100},
         )
 
@@ -348,13 +446,28 @@ class TestExplorerSavedViews:
         csv_resp.text = "workspace_name,all_checks_succeeded\ndemo,true\n"
         mock_transport.request.return_value = csv_resp
 
-        csv_text = explorer_service.saved_view_results_csv("acme", "sq-1")
+        csv_text = explorer_service.saved_view_results_csv(ORG, VIEW_ID)
         assert csv_text.splitlines()[0].startswith(
             "all_checks_succeeded,workspace_name"
         )
-        mock_transport.request.assert_called_once_with(
-            "GET", "/api/v2/organizations/acme/explorer/views/sq-1/csv"
+        _assert_single_request_call(
+            mock_transport, "GET", f"{VIEWS_PATH}/{VIEW_ID}/csv"
         )
+
+    def test_saved_view_results_csv_invalid_csv_returns_raw(
+        self, explorer_service, mock_transport, monkeypatch
+    ):
+        csv_resp = Mock()
+        csv_resp.text = "raw-csv"
+        mock_transport.request.return_value = csv_resp
+
+        def _raise_csv_error(*_args, **_kwargs):
+            raise csv.Error("invalid csv")
+
+        monkeypatch.setattr("pytfe.resources.explorer.csv.reader", _raise_csv_error)
+
+        csv_text = explorer_service.saved_view_results_csv(ORG, VIEW_ID)
+        assert csv_text == "raw-csv"
 
     def test_saved_view_results_csv_fallback_to_export(
         self, explorer_service, mock_transport
@@ -366,7 +479,20 @@ class TestExplorerSavedViews:
         export_resp.text = "workspace_name\nfrom-export\n"
         mock_transport.request.side_effect = [first, read_resp, export_resp]
 
-        csv_text = explorer_service.saved_view_results_csv("acme", "sq-1")
+        csv_text = explorer_service.saved_view_results_csv(ORG, VIEW_ID)
+        assert "from-export" in csv_text
+
+    def test_saved_view_results_csv_server_error_fallback_to_export(
+        self, explorer_service, mock_transport
+    ):
+        first = ServerError("server error", status=500)
+        read_resp = Mock()
+        read_resp.json.return_value = {"data": _saved_view_payload("sq-1")}
+        export_resp = Mock()
+        export_resp.text = "workspace_name\nfrom-export\n"
+        mock_transport.request.side_effect = [first, read_resp, export_resp]
+
+        csv_text = explorer_service.saved_view_results_csv(ORG, VIEW_ID)
         assert "from-export" in csv_text
 
     def test_saved_view_results_csv_fallback_to_rows(
@@ -387,7 +513,7 @@ class TestExplorerSavedViews:
             second_results,  # saved_view_results page 2
         ]
 
-        csv_text = explorer_service.saved_view_results_csv("acme", "sq-1")
+        csv_text = explorer_service.saved_view_results_csv(ORG, VIEW_ID)
         header = csv_text.strip().splitlines()[0]
         assert header.startswith(
             "all_checks_succeeded,current_rum_count,checks_errored,checks_failed,"
@@ -405,16 +531,16 @@ class TestExplorerSavedViews:
             list(explorer_service.list_saved_views(org))
 
         with pytest.raises(InvalidOrgError):
-            explorer_service.read_saved_view(org, "sq-1")
+            explorer_service.read_saved_view(org, VIEW_ID)
 
     @pytest.mark.parametrize("view_id", ["", None])
     def test_saved_view_methods_invalid_id(self, explorer_service, view_id):
         with pytest.raises(InvalidExplorerSavedViewIDError):
-            explorer_service.read_saved_view("acme", view_id)
+            explorer_service.read_saved_view(ORG, view_id)
 
         with pytest.raises(InvalidExplorerSavedViewIDError):
             explorer_service.update_saved_view(
-                "acme",
+                ORG,
                 view_id,
                 ExplorerSavedViewUpdateOptions(
                     name="updated",
@@ -423,10 +549,10 @@ class TestExplorerSavedViews:
             )
 
         with pytest.raises(InvalidExplorerSavedViewIDError):
-            explorer_service.delete_saved_view("acme", view_id)
+            explorer_service.delete_saved_view(ORG, view_id)
 
         with pytest.raises(InvalidExplorerSavedViewIDError):
-            list(explorer_service.saved_view_results("acme", view_id))
+            list(explorer_service.saved_view_results(ORG, view_id))
 
         with pytest.raises(InvalidExplorerSavedViewIDError):
-            explorer_service.saved_view_results_csv("acme", view_id)
+            explorer_service.saved_view_results_csv(ORG, view_id)

--- a/tests/units/test_explorer.py
+++ b/tests/units/test_explorer.py
@@ -181,6 +181,138 @@ class TestExplorerQuery:
         mock_transport.request.assert_has_calls(expected_calls)
         assert mock_transport.request.call_count == 4
 
+    def test_query_uses_pagination_meta_when_server_caps_page_size(
+        self, explorer_service, mock_transport
+    ):
+        first = Mock()
+        first.json.return_value = {
+            "data": [_row_payload("ws-1"), _row_payload("ws-2")],
+            "meta": {
+                "pagination": {
+                    "current-page": 1,
+                    "page-size": 2,
+                    "next-page": 2,
+                    "total-pages": 2,
+                }
+            },
+        }
+        second = Mock()
+        second.json.return_value = {
+            "data": [_row_payload("ws-3")],
+            "meta": {
+                "pagination": {
+                    "current-page": 2,
+                    "page-size": 2,
+                    "next-page": None,
+                    "total-pages": 2,
+                }
+            },
+        }
+        mock_transport.request.side_effect = [first, second]
+
+        options = ExplorerQueryOptions(
+            view_type=ExplorerViewType.WORKSPACES,
+            page_size=50,
+        )
+
+        rows = list(explorer_service.query(ORG, options))
+        assert [row.id for row in rows] == ["ws-1", "ws-2", "ws-3"]
+
+        expected_calls = [
+            call(
+                "GET",
+                EXPLORER_PATH,
+                params={"type": "workspaces", "page[size]": 50, "page[number]": 1},
+            ),
+            call(
+                "GET",
+                EXPLORER_PATH,
+                params={"type": "workspaces", "page[size]": 50, "page[number]": 2},
+            ),
+        ]
+        mock_transport.request.assert_has_calls(expected_calls)
+        assert mock_transport.request.call_count == 2
+
+    def test_query_uses_current_and_total_pages_when_next_page_missing(
+        self, explorer_service, mock_transport
+    ):
+        first = Mock()
+        first.json.return_value = {
+            "data": [_row_payload("ws-1")],
+            "meta": {"pagination": {"current-page": 1, "total-pages": 2}},
+        }
+        second = Mock()
+        second.json.return_value = {
+            "data": [_row_payload("ws-2")],
+            "meta": {"pagination": {"current-page": 2, "total-pages": 2}},
+        }
+        mock_transport.request.side_effect = [first, second]
+
+        rows = list(
+            explorer_service.query(
+                ORG, ExplorerQueryOptions(view_type=ExplorerViewType.WORKSPACES)
+            )
+        )
+        assert [row.id for row in rows] == ["ws-1", "ws-2"]
+
+        expected_calls = [
+            call(
+                "GET",
+                EXPLORER_PATH,
+                params={"type": "workspaces", "page[number]": 1, "page[size]": 100},
+            ),
+            call(
+                "GET",
+                EXPLORER_PATH,
+                params={"type": "workspaces", "page[number]": 2, "page[size]": 100},
+            ),
+        ]
+        mock_transport.request.assert_has_calls(expected_calls)
+        assert mock_transport.request.call_count == 2
+
+    def test_query_stops_when_pagination_meta_does_not_advance(
+        self, explorer_service, mock_transport
+    ):
+        first = Mock()
+        first.json.return_value = {
+            "data": [_row_payload("ws-1")],
+            "meta": {"pagination": {"current-page": 1, "total-pages": 2}},
+        }
+        second = Mock()
+        second.json.return_value = {
+            "data": [_row_payload("ws-1")],
+            "meta": {"pagination": {"current-page": 1, "total-pages": 2}},
+        }
+        mock_transport.request.side_effect = [first, second]
+
+        rows = list(
+            explorer_service.query(
+                ORG, ExplorerQueryOptions(view_type=ExplorerViewType.WORKSPACES)
+            )
+        )
+        assert [row.id for row in rows] == ["ws-1", "ws-1"]
+        assert mock_transport.request.call_count == 2
+
+    def test_query_stops_on_empty_page_even_if_next_page_present(
+        self, explorer_service, mock_transport
+    ):
+        first = Mock()
+        first.json.return_value = {
+            "data": [],
+            "meta": {
+                "pagination": {"current-page": 1, "next-page": 2, "total-pages": 5}
+            },
+        }
+        mock_transport.request.return_value = first
+
+        rows = list(
+            explorer_service.query(
+                ORG, ExplorerQueryOptions(view_type=ExplorerViewType.WORKSPACES)
+            )
+        )
+        assert rows == []
+        assert mock_transport.request.call_count == 1
+
     def test_query_invalid_org(self, explorer_service):
         with pytest.raises(InvalidOrgError):
             list(
@@ -379,50 +511,21 @@ class TestExplorerSavedViews:
             explorer_service.update_saved_view(ORG, VIEW_ID, options)
 
     def test_delete_saved_view(self, explorer_service, mock_transport):
-        response = Mock()
-        response.json.return_value = {"data": _saved_view_payload("sq-1")}
-        response.text = '{"data":{"id":"sq-1"}}'
-        mock_transport.request.return_value = response
-
-        view = explorer_service.delete_saved_view(ORG, VIEW_ID)
-        assert view.id == "sq-1"
+        result = explorer_service.delete_saved_view(ORG, VIEW_ID)
+        assert result is None
 
         _assert_single_request_call(mock_transport, "DELETE", f"{VIEWS_PATH}/{VIEW_ID}")
 
-    def test_delete_saved_view_empty_response(self, explorer_service, mock_transport):
-        response = Mock()
-        response.text = ""
-        response.json.side_effect = ValueError("No JSON body")
-        mock_transport.request.return_value = response
-
-        view = explorer_service.delete_saved_view(ORG, VIEW_ID)
-        assert view.id == "sq-1"
-
-    def test_delete_saved_view_non_json_body_returns_stub(
+    def test_delete_saved_view_ignores_response_body(
         self, explorer_service, mock_transport
     ):
         response = Mock()
-        response.text = "deleted"
+        response.text = '{"data":{"id":"unexpected"}}'
         response.json.side_effect = ValueError("No JSON body")
         mock_transport.request.return_value = response
 
-        view = explorer_service.delete_saved_view(ORG, VIEW_ID)
-        assert view.id == "sq-1"
-        assert view.name == ""
-        assert view.query_type == ExplorerViewType.WORKSPACES
-
-    def test_delete_saved_view_invalid_data_shape_returns_stub(
-        self, explorer_service, mock_transport
-    ):
-        response = Mock()
-        response.text = '{"data":[]}'
-        response.json.return_value = {"data": []}
-        mock_transport.request.return_value = response
-
-        view = explorer_service.delete_saved_view(ORG, VIEW_ID)
-        assert view.id == "sq-1"
-        assert view.name == ""
-        assert view.query_type == ExplorerViewType.WORKSPACES
+        result = explorer_service.delete_saved_view(ORG, VIEW_ID)
+        assert result is None
 
     def test_saved_view_results(self, explorer_service, mock_transport):
         first = Mock()


### PR DESCRIPTION
## 📌 Description

This PR adds support for the **HCP Terraform / Terraform Enterprise Explorer API (v2)** to pytfe, exposed via:

```python
TFEClient.explorer
```

The Explorer API enables **organization-scoped visibility and analytics**, including:

* Workspaces
* Terraform versions
* Registry providers
* Modules

It also supports:

* CSV export
* Saved views (CRUD operations)
* Re-running saved views (JSON / CSV)

This implementation covers public v2 routes under:

```
/api/v2/organizations/:organization/explorer
/api/v2/organizations/:organization/explorer/views/*
```

---

## ✨ Changes Included

### 📦 Models

* Added new Pydantic models:

  * `src/pytfe/models/explorer.py`
* Exported models via:

  * `src/pytfe/models/__init__.py`

### 🔧 Resources

* Added new resource:

  * `Explorer` → `src/pytfe/resources/explorer.py`
* Pagination aligned with existing `_Service` patterns

### 🧠 Client

* Added:

  ```python
  TFEClient.explorer
  ```

  in `src/pytfe/client.py`

### ❗ Errors

* Introduced:

  * `InvalidExplorerSavedViewIDError` in `src/pytfe/errors.py`

### 🧪 Tests

* Added unit tests with mocked HTTP:

  * `tests/units/test_explorer.py`

### 📘 Examples

* Added usage example:

  * `examples/explorer.py`

### 📝 Changelog

* Updated:

  * `CHANGELOG.md` under `v0.2.0 (Unreleased)`

---

## 🧪 Testing Plan

### 🔹 Local (No live cluster)

```bash
make dev-install   # Python ≥ 3.10
make check
make test
```

---

### 🔹 Optional (Live HCP Terraform / TFE)

Set environment variables:

```bash
export TFE_ADDRESS=<your-address>
export TFE_TOKEN=<your-token>
export TFE_ORGANIZATION=<your-org>
```

Run:

```bash
python examples/explorer.py
```

#### Optional (Saved View flows)

```bash
export TFE_EXPLORER_VIEW_ID=<view-id>
export TFE_EXPLORER_DEMO_MUTATIONS=1
```

> ⚠️ This will perform create/update/delete operations on a uniquely named view.

Ensure:

* Token has required Explorer API permissions
* Organization access is valid

---

## 🔄 Rollback Plan

* Revert this PR from `main`
* Removes:

  * `client.explorer`
  * Explorer models/resources/tests

✅ No infra or migration rollback required

---

## 🔐 Changes to Security Controls

* No changes in this repository
* Authentication:

  * Uses existing `HTTPTransport` + bearer token
* Authorization:

  * Enforced by HCP Terraform / TFE APIs

---

## ✅ PCI Review Checklist

* [x] Clear description and justification provided
* [x] Rollback plan documented (PR revert sufficient)
* [x] No changes to security controls

---

## 🧾 CONTRIBUTING Checklist

* [x] Code formatted (`make fmt`)
* [x] Lint passes (`make lint`)
* [x] Type checks pass (`make type-check`)
* [x] Tests pass (`make test`)
* [x] Unit tests added for new functionality
* [x] `CHANGELOG.md` updated
* [x] Example added under `examples/`
* [x] Docstrings added for public classes/methods