### PR TITLE
Feature tf-policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ protos.bin
 # Local RSA keys
 .local/*
 
+# Bob files
+.bob/
+_context/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Unreleased
 
+## Enhancements
+
+### New resources
+
+* Added `client.tf_policy_evaluations` — read and override tf-policy evaluations
+  attached to a run.
+  * `list(run_id, options=None)` (`GET /runs/{run_id}/tf-policy-evaluations`) returns
+    an `Iterator[TfPolicyEvaluation]`.
+  * `read(tf_policy_evaluation_id, options=None)` (`GET /tf-policy-evaluations/{id}`)
+    returns a single `TfPolicyEvaluation`; pass
+    `TfPolicyEvaluationListOptions(include="tf_policy_set_outcomes")` to sideload
+    outcomes in one request.
+  * `override(tf_policy_evaluation_id, options=None)` (`POST
+    /tf-policy-evaluations/{id}/actions/override`) overrides an evaluation in
+    `awaiting_override` status and returns the updated resource.
+  * `list_set_outcomes(tf_policy_evaluation_id, options=None)` (`GET
+    /tf-policy-evaluations/{id}/tf-policy-set-outcomes`) returns an
+    `Iterator[TfPolicySetOutcome]`; supports `filter_status` and
+    `filter_enforcement_level` via `TfPolicySetOutcomeListOptions`.
+  * New models: `TfPolicyEvaluation`, `TfPolicyEvaluationStatusTimestamps`,
+    `TfPolicyResultCount`, `TfPolicyEvaluationError`, `TfPolicyEvaluationPermissions`,
+    `TfPolicyEvaluationActions`, `TfPolicyEvaluationListOptions`,
+    `TfPolicyEvaluationOverrideOptions`.
+  * New errors: `InvalidTfPolicyEvaluationIDError`.
+* Added `client.tf_policy_set_outcomes` — read a single tf-policy set outcome.
+  * `read(tf_policy_set_outcome_id)` (`GET /tf-policy-set-outcomes/{id}`) returns a
+    `TfPolicySetOutcome` with its nested `outcomes` array (snake_case inner keys, as
+    stored by atlas).
+  * New models: `TfPolicySetOutcome`, `PolicyOutcome`, `Diagnostic`, `OutcomeResource`,
+    `TraversalValue`, `PassedResource`, `TfPolicySetOutcomeListOptions`.
+  * New error: `InvalidTfPolicySetOutcomeIDError`.
+
+### New enum values
+
+* `PolicyKind.TFPOLICY = "tfpolicy"` — enables creating and reading tf-policy sets
+  with the existing `client.policy_sets` resource.
+* New enums: `TfPolicyEvaluationStatus`, `TfPolicyStage`, `TfPolicyEnforcementLevel`.
+
 # Released
 # v1.3.0
 

--- a/docs/scenarios/tf-policy-evaluation.md
+++ b/docs/scenarios/tf-policy-evaluation.md
@@ -1,0 +1,206 @@
+# Scenario: tf-policy evaluation and override
+
+This scenario covers reading tf-policy compliance results for a run, filtering
+policy-set outcomes, and overriding a `mandatory_overridable` failure. tf-policy
+is HCP Terraform's native policy-as-code engine (distinct from Sentinel and
+OPA) — evaluations are attached to a run's stages (Init/Plan/Apply) rather
+than created directly, so this scenario reads and reacts to results rather
+than authoring them.
+
+> tf-policy is HCP Terraform only and gated behind an organization-level
+> feature flag while in private beta. If policy-set creation with
+> `kind=PolicyKind.TFPOLICY` fails validation, confirm the flag is enabled for
+> your organization before assuming a client-side issue.
+
+## Prerequisites
+
+```bash
+export TFE_TOKEN="your-api-token"
+export TFE_ADDRESS="https://app.terraform.io"
+```
+
+The workspace whose runs you're inspecting must be running a Terraform
+version tf-policy supports (`>= 1.16.0-alpha20260626` at the time of writing —
+check with your organization admin, since this is a fast-moving minimum on a
+beta feature). Evaluations on an older version come back `errored` with an
+`incompatible_terraform_version_error`, not a client-side exception.
+
+## Step 1: List a run's tf-policy evaluations
+
+A run has one evaluation per applicable stage. `resource_policy` findings
+typically only show up at the Plan stage — Init-stage evaluations commonly
+pass trivially with an empty result count, so don't assume `list()[0]` is the
+interesting one.
+
+```python
+from pytfe import TFEClient
+
+client = TFEClient()
+run_id = "run-abc123"
+
+evaluations = list(client.tf_policy_evaluations.list(run_id))
+for e in evaluations:
+    print(e.id, e.stage_type, e.status, e.result_count)
+```
+
+## Step 2: Read one evaluation, with outcomes sideloaded
+
+```python
+from pytfe.models import TfPolicyEvaluationListOptions
+
+opts = TfPolicyEvaluationListOptions(include="tf_policy_set_outcomes")
+evaluation = client.tf_policy_evaluations.read(evaluations[0].id, options=opts)
+
+print(evaluation.status, evaluation.actions, evaluation.permissions)
+```
+
+`evaluation.actions.is_overridable` and `evaluation.permissions.can_override`
+both need to be `True` before an override call will succeed — check them
+before attempting one rather than relying on the error path.
+
+## Step 3: Inspect policy-set outcomes and diagnostics
+
+```python
+for outcome in client.tf_policy_evaluations.list_set_outcomes(evaluation.id):
+    print(outcome.policy_set_name, outcome.result_count)
+    for policy in outcome.outcomes:
+        print(" ", policy.policy_name, policy.status, policy.enforcement_level)
+        for diag in policy.diagnostics:
+            print("    diag:", diag.summary, [r.resource_name for r in diag.resources])
+```
+
+Filter to just the failures, or just one enforcement level:
+
+```python
+from pytfe.models import TfPolicySetOutcomeListOptions
+
+failed = client.tf_policy_evaluations.list_set_outcomes(
+    evaluation.id,
+    options=TfPolicySetOutcomeListOptions(filter_status="failed"),
+)
+
+mandatory_overridable = client.tf_policy_evaluations.list_set_outcomes(
+    evaluation.id,
+    options=TfPolicySetOutcomeListOptions(
+        filter_enforcement_level="mandatory_overridable"
+    ),
+)
+```
+
+You can also read a single outcome directly if you already have its ID (e.g.
+from a webhook payload) without listing through the evaluation:
+
+```python
+outcome = client.tf_policy_set_outcomes.read("tfpsout-abc123")
+```
+
+## Step 4: Override a `mandatory_overridable` failure
+
+```python
+from pytfe.models import TfPolicyEvaluationOverrideOptions
+
+result = client.tf_policy_evaluations.override(
+    evaluation.id,
+    TfPolicyEvaluationOverrideOptions(comment="Approved by platform-team — ticket OPS-123"),
+)
+print(result.status)  # "overridden"
+```
+
+`comment` is optional — omit `options` entirely to override with no comment.
+The override only succeeds while the evaluation is in `awaiting_override`
+status; calling it again on an already-overridden evaluation raises `TFEError`
+rather than silently no-op'ing, so guard on `status` first if you're looping
+over a batch:
+
+```python
+from pytfe.models import TfPolicyEvaluationStatus
+
+overridable = [
+    e for e in evaluations
+    if e.status == TfPolicyEvaluationStatus.AWAITING_OVERRIDE
+    and e.actions and e.actions.is_overridable
+]
+for e in overridable:
+    client.tf_policy_evaluations.override(e.id)
+```
+
+## Step 5: Gate a downstream workflow on compliance
+
+The read-only surface above is enough to build a pre-flight compliance gate —
+this is the pattern the `hashicorp.terraform` Ansible collection's
+`tf_policy_evaluation_info` module wraps:
+
+```python
+evaluations = list(client.tf_policy_evaluations.list(run_id))
+non_compliant = [
+    e for e in evaluations
+    if e.status in (
+        TfPolicyEvaluationStatus.FAILED,
+        TfPolicyEvaluationStatus.ERRORED,
+        TfPolicyEvaluationStatus.AWAITING_OVERRIDE,
+    )
+]
+if non_compliant:
+    raise SystemExit(f"Run {run_id} is not tf-policy compliant: {non_compliant}")
+```
+
+## Creating a `kind=tfpolicy` policy set
+
+Policy sets of this kind don't require a VCS connection — upload policy files
+directly for the fastest iteration loop:
+
+```python
+from pytfe.models import PolicyKind, PolicySetCreateOptions
+
+policy_set = client.policy_sets.create(
+    "my-organization",
+    PolicySetCreateOptions(
+        name="tfpolicy-guardrails",
+        kind=PolicyKind.TFPOLICY,
+        policy_tool_version="0.1.0",
+        agent_enabled=True,
+        overridable=True,
+    ),
+)
+
+version = client.policy_set_versions.create(policy_set.id)
+client.policy_set_versions.upload(version, "./policies")  # directory, not a tarball
+```
+
+`client.policy_set_versions.upload()` takes the `PolicySetVersion` object
+itself (it reads the upload link off it), not a URL string — this differs
+from `client.configuration_versions.upload()`, which does take the upload URL
+directly. Easy to transpose the two if you're working with both in the same
+script.
+
+The directory passed to `upload()` must have `.policy.hcl` files **flat at
+its root** — no subdirectory — unless `policies_path` is set on the policy
+set. A nested layout is accepted without error and silently evaluates zero
+policies, which is a confusing failure mode: every evaluation "passes" with
+`result_count` at all zeros, indistinguishable from a genuinely compliant run
+until you notice nothing was actually checked.
+
+## Cleanup
+
+```python
+client.policy_sets.delete(policy_set.id)
+```
+
+Evaluations themselves aren't deletable - they're immutable records tied to
+the run that produced them and are cleaned up when the run/workspace is.
+
+## Wire-format notes
+
+- `TfPolicyEnforcementLevel.MANDATORY_OVERRIDABLE` serializes as
+  `"mandatory_overridable"` - underscore, unlike the hyphenated style used
+  elsewhere in the JSON:API surface.
+- The `outcomes` array on `TfPolicySetOutcome`, and everything nested inside
+  it (`PolicyOutcome`, `Diagnostic`, `OutcomeResource`, `TraversalValue`,
+  `PassedResource`), is **snake_case on the wire** rather than dash-cased.
+  The backend serializes that column verbatim from a stored value rather than
+  passing it through the usual attribute-name transform, so the SDK models
+  read it as-is — this is intentional, not a bug, if you're ever comparing
+  raw JSON against the rest of the API's dash-case convention.
+- `override()`'s request body is a bare `{"comment": "..."}`, not a JSON:API
+  `{"data": {"attributes": {...}}}` envelope - the SDK handles this for you,
+  but it's worth knowing if you're debugging against raw HTTP logs.

--- a/examples/oauth_client.py
+++ b/examples/oauth_client.py
@@ -241,7 +241,7 @@ def main():
                 print(" OAuth Token details:")
                 for i, token in enumerate(read_oauth_client.oauth_tokens[:2], 1):
                     if isinstance(token, dict):
-                        print(f"{i}. Token ID: {token.get('id', 'N/A')}")
+                        print(f"{i}. Token details: [REDACTED]")
 
         except Exception as e:
             print(f"Error reading OAuth client with options: {e}")

--- a/examples/tf_policy_evaluation.py
+++ b/examples/tf_policy_evaluation.py
@@ -1,0 +1,180 @@
+# Copyright IBM Corp. 2025, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+"""tf-policy evaluation demo for the python-tfe SDK.
+
+Usage examples::
+
+    # List evaluations for a run:
+    python examples/tf_policy_evaluation.py --run-id run-abc123
+
+    # Read a specific evaluation with sideloaded set outcomes:
+    python examples/tf_policy_evaluation.py --run-id run-abc123 --read tfpeval-abc123
+
+    # List evaluations and override any awaiting_override ones (dry-run):
+    python examples/tf_policy_evaluation.py --run-id run-abc123 --override --dry-run
+
+    # Override with a comment:
+    python examples/tf_policy_evaluation.py --run-id run-abc123 --override \
+        --comment "Approved by ops team — ticket OPS-123"
+
+Environment variables::
+
+    TFE_TOKEN    - HCP Terraform / TFE API token (required)
+    TFE_ADDRESS  - API address (default: https://app.terraform.io)
+    TFE_RUN_ID   - Run ID (overridden by --run-id)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+from pytfe import TFEClient, TFEConfig
+from pytfe.models import (
+    TfPolicyEvaluationListOptions,
+    TfPolicyEvaluationOverrideOptions,
+    TfPolicyEvaluationStatus,
+)
+
+
+def _print_header(title: str) -> None:
+    print("\n" + "=" * 80)
+    print(title)
+    print("=" * 80)
+
+
+def _print_result_count(result_count) -> None:  # type: ignore[no-untyped-def]
+    if result_count is None:
+        return
+    print(
+        f"  result-count: passed={result_count.passed}  "
+        f"advisory-failed={result_count.advisory_failed}  "
+        f"mandatory-failed={result_count.mandatory_failed}  "
+        f"errored={result_count.errored}  unknown={result_count.unknown}"
+    )
+
+
+def _print_evaluation(evaluation) -> None:  # type: ignore[no-untyped-def]
+    print(f"  id:          {evaluation.id}")
+    print(f"  status:      {evaluation.status}")
+    print(f"  stage-type:  {evaluation.stage_type}")
+    _print_result_count(evaluation.result_count)
+    if evaluation.error:
+        print(f"  error:       [{evaluation.error.type}] {evaluation.error.summary}")
+    if evaluation.actions:
+        print(f"  overridable: {evaluation.actions.is_overridable}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="tf-policy evaluation demo")
+    parser.add_argument(
+        "--address", default=os.getenv("TFE_ADDRESS", "https://app.terraform.io")
+    )
+    parser.add_argument("--token", default=os.getenv("TFE_TOKEN", ""))
+    parser.add_argument(
+        "--run-id",
+        default=os.getenv("TFE_RUN_ID", ""),
+        help="Run ID (e.g. run-abc123)",
+    )
+    parser.add_argument(
+        "--read",
+        metavar="EVAL_ID",
+        help="Read a specific evaluation by ID (e.g. tfpeval-abc123)",
+    )
+    parser.add_argument(
+        "--override",
+        action="store_true",
+        help="Override any evaluations that are in awaiting_override status",
+    )
+    parser.add_argument(
+        "--comment",
+        default="",
+        help="Comment to attach when overriding",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be overridden without sending the request",
+    )
+    args = parser.parse_args()
+
+    if not args.token:
+        print("error: TFE_TOKEN is not set")
+        return 2
+    if not args.run_id and not args.read:
+        print("error: --run-id or --read is required")
+        return 2
+
+    client = TFEClient(TFEConfig(address=args.address, token=args.token))
+
+    try:
+        # ── Read a single evaluation ──────────────────────────────────────────
+        if args.read:
+            _print_header(f"Reading evaluation: {args.read}")
+            opts = TfPolicyEvaluationListOptions(include="tf_policy_set_outcomes")
+            evaluation = client.tf_policy_evaluations.read(args.read, options=opts)
+            _print_evaluation(evaluation)
+
+            # Drill into set outcomes
+            _print_header("Policy-set outcomes (nested list)")
+            outcomes = list(client.tf_policy_evaluations.list_set_outcomes(args.read))
+            if not outcomes:
+                print("  No set outcomes found.")
+            for outcome in outcomes:
+                print(f"\n  outcome id:  {outcome.id}")
+                print(f"  policy-set:  {outcome.policy_set_name}")
+                print(f"  overridable: {outcome.overridable}")
+                _print_result_count(outcome.result_count)
+                for o in outcome.outcomes:
+                    marker = "PASS" if str(o.status) == "passed" else "FAIL"
+                    print(
+                        f"    [{marker}] {o.policy_name}  "
+                        f"enforcement={o.enforcement_level}  status={o.status}"
+                    )
+            return 0
+
+        # ── List evaluations for a run ────────────────────────────────────────
+        _print_header(f"tf-policy evaluations for run: {args.run_id}")
+        evaluations = list(client.tf_policy_evaluations.list(args.run_id))
+        if not evaluations:
+            print("  No tf-policy evaluations found for this run.")
+            return 0
+
+        overridable_ids: list[str] = []
+        for evaluation in evaluations:
+            _print_evaluation(evaluation)
+            print()
+            if evaluation.status == TfPolicyEvaluationStatus.AWAITING_OVERRIDE:
+                overridable_ids.append(evaluation.id)
+
+        print(f"Total: {len(evaluations)} evaluation(s).")
+
+        # ── Optional override ─────────────────────────────────────────────────
+        if args.override:
+            if not overridable_ids:
+                print("\nNo evaluations are awaiting override.")
+                return 0
+
+            for eval_id in overridable_ids:
+                if args.dry_run:
+                    print(f"\n[dry-run] Would override {eval_id}")
+                    continue
+
+                _print_header(f"Overriding evaluation: {eval_id}")
+                override_opts = (
+                    TfPolicyEvaluationOverrideOptions(comment=args.comment)
+                    if args.comment
+                    else None
+                )
+                result = client.tf_policy_evaluations.override(eval_id, override_opts)
+                print(f"  new status: {result.status}")
+
+    finally:
+        client.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pytfe"
-version = "1.3.0"
+version = "1.3.1"
 description = "Official Python SDK for HashiCorp Terraform Cloud / Terraform Enterprise (TFE) API v2"
 readme = "README.md"
 license = { text = "MPL-2.0" }
@@ -48,6 +48,7 @@ packages = ["src/pytfe"]
 target-version = "py310"
 line-length = 88
 exclude = [
+    ".bob",
     ".bzr",
     ".direnv",
     ".eggs",
@@ -90,6 +91,7 @@ quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
+exclude = ["*.md"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["pytfe"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pytfe"
-version = "1.3.1"
+version = "1.4.0"
 description = "Official Python SDK for HashiCorp Terraform Cloud / Terraform Enterprise (TFE) API v2"
 readme = "README.md"
 license = { text = "MPL-2.0" }

--- a/src/pytfe/_http.py
+++ b/src/pytfe/_http.py
@@ -102,7 +102,7 @@ class HTTPTransport:
                 )
             except httpx.HTTPError as e:
                 transport_logger.debug(
-                    "transport exception on %s %s (attempt %d): %s",
+                    "transport exception on %s (attempt %d): %s",
                     method,
                     attempt,
                     e,
@@ -122,7 +122,7 @@ class HTTPTransport:
             if resp.status_code in _RETRY_STATUSES and attempt < self.max_retries:
                 retry_after = _parse_retry_after(resp)
                 transport_logger.info(
-                    "retrying %s %s after %s (status=%d, attempt=%d)",
+                    "retrying %s after %s (status=%d, attempt=%d)",
                     method,
                     f"{retry_after:.2f}s" if retry_after else "backoff",
                     resp.status_code,

--- a/src/pytfe/_http.py
+++ b/src/pytfe/_http.py
@@ -104,7 +104,6 @@ class HTTPTransport:
                 transport_logger.debug(
                     "transport exception on %s %s (attempt %d): %s",
                     method,
-                    "<redacted-url>",
                     attempt,
                     e,
                 )
@@ -125,7 +124,6 @@ class HTTPTransport:
                 transport_logger.info(
                     "retrying %s %s after %s (status=%d, attempt=%d)",
                     method,
-                    "<redacted-url>",
                     f"{retry_after:.2f}s" if retry_after else "backoff",
                     resp.status_code,
                     attempt,

--- a/src/pytfe/_http.py
+++ b/src/pytfe/_http.py
@@ -104,7 +104,7 @@ class HTTPTransport:
                 transport_logger.debug(
                     "transport exception on %s %s (attempt %d): %s",
                     method,
-                    url,
+                    "<redacted-url>",
                     attempt,
                     e,
                 )
@@ -125,7 +125,7 @@ class HTTPTransport:
                 transport_logger.info(
                     "retrying %s %s after %s (status=%d, attempt=%d)",
                     method,
-                    url,
+                    "<redacted-url>",
                     f"{retry_after:.2f}s" if retry_after else "backoff",
                     resp.status_code,
                     attempt,

--- a/src/pytfe/client.py
+++ b/src/pytfe/client.py
@@ -77,6 +77,8 @@ from .resources.team import Teams
 from .resources.team_project_access import TeamProjectAccesses
 from .resources.team_token import TeamTokens
 from .resources.team_workspace_access import TeamWorkspaceAccesses
+from .resources.tf_policy_evaluation import TfPolicyEvaluations
+from .resources.tf_policy_set_outcome import TfPolicySetOutcomes
 from .resources.user import Users
 from .resources.variable import Variables
 from .resources.variable_sets import VariableSets, VariableSetVariables
@@ -245,6 +247,8 @@ class TFEClient:
         self.policy_set_parameters = PolicySetParameters(self._transport)
         self.policy_set_outcomes = PolicySetOutcomes(self._transport)
         self.policy_set_versions = PolicySetVersions(self._transport)
+        self.tf_policy_evaluations = TfPolicyEvaluations(self._transport)
+        self.tf_policy_set_outcomes = TfPolicySetOutcomes(self._transport)
 
         # SSH Keys
         self.ssh_keys = SSHKeys(self._transport)

--- a/src/pytfe/errors.py
+++ b/src/pytfe/errors.py
@@ -652,6 +652,21 @@ class InvalidPolicySetOutcomeIDError(InvalidValues):
         super().__init__(message)
 
 
+# tf-policy errors
+class InvalidTfPolicyEvaluationIDError(InvalidValues):
+    """Raised when a tf-policy evaluation ID (``tfpeval-``) is invalid."""
+
+    def __init__(self, message: str = "invalid value for tf-policy evaluation ID"):
+        super().__init__(message)
+
+
+class InvalidTfPolicySetOutcomeIDError(InvalidValues):
+    """Raised when a tf-policy set outcome ID (``tfpsout-``) is invalid."""
+
+    def __init__(self, message: str = "invalid value for tf-policy set outcome ID"):
+        super().__init__(message)
+
+
 # Registry Provider Version errors
 class RequiredPrivateRegistryError(RequiredFieldMissing):
     """Raised when a required private registry field is missing."""

--- a/src/pytfe/models/__init__.py
+++ b/src/pytfe/models/__init__.py
@@ -349,6 +349,9 @@ from .policy_set_version import PolicySetVersion
 from .policy_types import (
     EnforcementLevel,
     PolicyKind,
+    TfPolicyEnforcementLevel,
+    TfPolicyEvaluationStatus,
+    TfPolicyStage,
 )
 from .project import (
     Project,
@@ -652,6 +655,25 @@ from .team_workspace_access import (
     TeamWorkspaceSentinelMocksPermission,
     TeamWorkspaceStateVersionsPermission,
     TeamWorkspaceVariablesPermission,
+)
+from .tf_policy_evaluation import (
+    TfPolicyEvaluation,
+    TfPolicyEvaluationActions,
+    TfPolicyEvaluationError,
+    TfPolicyEvaluationListOptions,
+    TfPolicyEvaluationOverrideOptions,
+    TfPolicyEvaluationPermissions,
+    TfPolicyEvaluationStatusTimestamps,
+    TfPolicyResultCount,
+)
+from .tf_policy_set_outcome import (
+    Diagnostic,
+    OutcomeResource,
+    PassedResource,
+    PolicyOutcome,
+    TfPolicySetOutcome,
+    TfPolicySetOutcomeListOptions,
+    TraversalValue,
 )
 from .user import (
     User,
@@ -1254,6 +1276,27 @@ __all__ = [
     "PolicySetParameterUpdateOptions",
     "PolicyKind",
     "EnforcementLevel",
+    # tf-policy enums
+    "TfPolicyEvaluationStatus",
+    "TfPolicyStage",
+    "TfPolicyEnforcementLevel",
+    # tf-policy evaluations
+    "TfPolicyEvaluation",
+    "TfPolicyEvaluationStatusTimestamps",
+    "TfPolicyResultCount",
+    "TfPolicyEvaluationError",
+    "TfPolicyEvaluationPermissions",
+    "TfPolicyEvaluationActions",
+    "TfPolicyEvaluationListOptions",
+    "TfPolicyEvaluationOverrideOptions",
+    # tf-policy set outcomes
+    "TfPolicySetOutcome",
+    "PolicyOutcome",
+    "Diagnostic",
+    "OutcomeResource",
+    "TraversalValue",
+    "PassedResource",
+    "TfPolicySetOutcomeListOptions",
     # Variable Sets
     "Parent",
     "VariableSet",

--- a/src/pytfe/models/policy_types.py
+++ b/src/pytfe/models/policy_types.py
@@ -11,6 +11,7 @@ class PolicyKind(str, Enum):
 
     OPA = "opa"
     SENTINEL = "sentinel"
+    TFPOLICY = "tfpolicy"
 
 
 class EnforcementLevel(str, Enum):
@@ -20,3 +21,38 @@ class EnforcementLevel(str, Enum):
     ENFORCEMENT_MANDATORY = "mandatory"
     ENFORCEMENT_HARD = "hard-mandatory"
     ENFORCEMENT_SOFT = "soft-mandatory"
+
+
+class TfPolicyEvaluationStatus(str, Enum):
+    """Status values for a tf-policy evaluation lifecycle."""
+
+    PENDING = "pending"
+    QUEUED = "queued"
+    RUNNING = "running"
+    AWAITING_OVERRIDE = "awaiting_override"
+    PASSED = "passed"
+    FAILED = "failed"
+    OVERRIDDEN = "overridden"
+    ERRORED = "errored"
+    CANCELED = "canceled"
+    UNREACHABLE = "unreachable"  # Pseudo-state derived from run final state
+
+
+class TfPolicyStage(str, Enum):
+    """Stage type for a tf-policy evaluation (wire values are capital-initial)."""
+
+    INIT = "Init"
+    PLAN = "Plan"
+    APPLY = "Apply"
+
+
+class TfPolicyEnforcementLevel(str, Enum):
+    """Enforcement levels used by tf-policy outcomes.
+
+    Distinct from ``EnforcementLevel`` (Sentinel/OPA) — ``mandatory_overridable``
+    is tf-policy only and uses an underscore, not a hyphen.
+    """
+
+    ADVISORY = "advisory"
+    MANDATORY = "mandatory"
+    MANDATORY_OVERRIDABLE = "mandatory_overridable"

--- a/src/pytfe/models/tf_policy_evaluation.py
+++ b/src/pytfe/models/tf_policy_evaluation.py
@@ -1,0 +1,114 @@
+# Copyright IBM Corp. 2025, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ._base import TFEModel
+from .policy_types import TfPolicyEvaluationStatus, TfPolicyStage
+
+
+class TfPolicyEvaluationStatusTimestamps(BaseModel):
+    """Per-state timestamps recorded as a tf-policy evaluation progresses."""
+
+    model_config = ConfigDict(
+        populate_by_name=True, validate_by_name=True, extra="allow"
+    )
+
+    pending_at: datetime | None = Field(None, alias="pending-at")
+    queued_at: datetime | None = Field(None, alias="queued-at")
+    running_at: datetime | None = Field(None, alias="running-at")
+    awaiting_override_at: datetime | None = Field(None, alias="awaiting-override-at")
+    passed_at: datetime | None = Field(None, alias="passed-at")
+    failed_at: datetime | None = Field(None, alias="failed-at")
+    overridden_at: datetime | None = Field(None, alias="overridden-at")
+    errored_at: datetime | None = Field(None, alias="errored-at")
+    canceled_at: datetime | None = Field(None, alias="canceled-at")
+
+
+class TfPolicyResultCount(BaseModel):
+    """Aggregated result counts across all policy-set outcomes in an evaluation."""
+
+    model_config = ConfigDict(
+        populate_by_name=True, validate_by_name=True, extra="allow"
+    )
+
+    advisory_failed: int | None = Field(None, alias="advisory-failed")
+    mandatory_failed: int | None = Field(None, alias="mandatory-failed")
+    passed: int | None = Field(None, alias="passed")
+    errored: int | None = Field(None, alias="errored")
+    unknown: int | None = Field(None, alias="unknown")
+
+
+class TfPolicyEvaluationError(BaseModel):
+    """Evaluation-level error object (``null`` when no error occurred)."""
+
+    model_config = ConfigDict(
+        populate_by_name=True, validate_by_name=True, extra="allow"
+    )
+
+    type: str | None = Field(None, alias="type")
+    summary: str | None = Field(None, alias="summary")
+    detail: str | None = Field(None, alias="detail")
+
+
+class TfPolicyEvaluationPermissions(BaseModel):
+    """Caller permissions for a tf-policy evaluation."""
+
+    model_config = ConfigDict(
+        populate_by_name=True, validate_by_name=True, extra="allow"
+    )
+
+    can_override: bool | None = Field(None, alias="can-override")
+
+
+class TfPolicyEvaluationActions(BaseModel):
+    """Available actions for a tf-policy evaluation."""
+
+    model_config = ConfigDict(
+        populate_by_name=True, validate_by_name=True, extra="allow"
+    )
+
+    is_overridable: bool | None = Field(None, alias="is-overridable")
+
+
+class TfPolicyEvaluation(TFEModel):
+    """A tf-policy evaluation attached to a run stage."""
+
+    model_config = ConfigDict(
+        populate_by_name=True, validate_by_name=True, extra="allow"
+    )
+
+    id: str
+    status: TfPolicyEvaluationStatus | None = Field(None, alias="status")
+    stage_type: TfPolicyStage | None = Field(None, alias="stage-type")
+    status_timestamps: TfPolicyEvaluationStatusTimestamps | None = Field(
+        None, alias="status-timestamps"
+    )
+    result_count: TfPolicyResultCount | None = Field(None, alias="result-count")
+    error: TfPolicyEvaluationError | None = Field(None, alias="error")
+    permissions: TfPolicyEvaluationPermissions | None = Field(None, alias="permissions")
+    actions: TfPolicyEvaluationActions | None = Field(None, alias="actions")
+    created_at: datetime | None = Field(None, alias="created-at")
+    updated_at: datetime | None = Field(None, alias="updated-at")
+
+
+class TfPolicyEvaluationListOptions(BaseModel):
+    """Options for listing tf-policy evaluations under a run."""
+
+    model_config = ConfigDict(populate_by_name=True, validate_by_name=True)
+
+    page_size: int | None = Field(None, alias="page[size]")
+    page_number: int | None = Field(None, alias="page[number]")
+    include: str | None = Field(None, alias="include")
+
+
+class TfPolicyEvaluationOverrideOptions(BaseModel):
+    """Options for overriding a tf-policy evaluation in ``awaiting_override`` status."""
+
+    model_config = ConfigDict(populate_by_name=True, validate_by_name=True)
+
+    comment: str | None = None

--- a/src/pytfe/models/tf_policy_set_outcome.py
+++ b/src/pytfe/models/tf_policy_set_outcome.py
@@ -1,0 +1,139 @@
+# Copyright IBM Corp. 2025, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from ._base import TFEModel
+from .policy_types import TfPolicyEnforcementLevel, TfPolicyEvaluationStatus
+from .tf_policy_evaluation import TfPolicyResultCount
+
+
+class TraversalValue(BaseModel):
+    """A single traversal/statement pair within a policy diagnostic resource."""
+
+    model_config = ConfigDict(
+        populate_by_name=True, validate_by_name=True, extra="allow"
+    )
+
+    traversal: str | None = None
+    statement: str | None = None
+
+
+class OutcomeResource(BaseModel):
+    """A Terraform resource referenced in a policy diagnostic."""
+
+    model_config = ConfigDict(
+        populate_by_name=True, validate_by_name=True, extra="allow"
+    )
+
+    resource_name: str | None = None
+    error_message: str | None = None
+    info_message: str | None = None
+    file_name: str | None = None
+    code: str | None = None
+    start_line: int | None = None
+    values: list[TraversalValue] = Field(default_factory=list)
+
+    @field_validator("values", mode="before")
+    @classmethod
+    def _none_to_empty_list(cls, value: Any) -> Any:
+        return [] if value is None else value
+
+
+class Diagnostic(BaseModel):
+    """A single policy-evaluation diagnostic entry."""
+
+    model_config = ConfigDict(
+        populate_by_name=True, validate_by_name=True, extra="allow"
+    )
+
+    code: str | None = None
+    context: str | None = None
+    start_line: int | None = None
+    summary: str | None = None
+    error_message: str | None = None
+    resources: list[OutcomeResource] = Field(default_factory=list)
+
+    @field_validator("resources", mode="before")
+    @classmethod
+    def _none_to_empty_list(cls, value: Any) -> Any:
+        return [] if value is None else value
+
+
+class PassedResource(BaseModel):
+    """A Terraform resource that passed a policy check."""
+
+    model_config = ConfigDict(
+        populate_by_name=True, validate_by_name=True, extra="allow"
+    )
+
+    resource_name: str | None = None
+    info_messages: list[str] = Field(default_factory=list)
+
+    @field_validator("info_messages", mode="before")
+    @classmethod
+    def _none_to_empty_list(cls, value: Any) -> Any:
+        return [] if value is None else value
+
+
+class PolicyOutcome(BaseModel):
+    """The result of evaluating a single policy within a policy-set outcome.
+
+    Inner fields use snake_case as stored — atlas serialises the ``outcomes``
+    column verbatim and the AMS dash-transform does not reach inside it.
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True, validate_by_name=True, extra="allow"
+    )
+
+    policy_name: str | None = None
+    description: str | None = None
+    file_name: str | None = None
+    enforcement_level: TfPolicyEnforcementLevel | None = None
+    status: TfPolicyEvaluationStatus | None = None
+    diagnostics: list[Diagnostic] = Field(default_factory=list)
+    passed_resources: list[PassedResource] = Field(default_factory=list)
+
+    @field_validator("diagnostics", "passed_resources", mode="before")
+    @classmethod
+    def _none_to_empty_list(cls, value: Any) -> Any:
+        return [] if value is None else value
+
+
+class TfPolicySetOutcome(TFEModel):
+    """Results for a single policy set within a tf-policy evaluation."""
+
+    model_config = ConfigDict(
+        populate_by_name=True, validate_by_name=True, extra="allow"
+    )
+
+    id: str
+    outcomes: list[PolicyOutcome] = Field(default_factory=list, alias="outcomes")
+    error: str | None = Field(None, alias="error")
+    overridable: bool | None = Field(None, alias="overridable")
+    policy_set_name: str | None = Field(None, alias="policy-set-name")
+    policy_set_description: str | None = Field(None, alias="policy-set-description")
+    result_count: TfPolicyResultCount | None = Field(None, alias="result-count")
+
+    @field_validator("outcomes", mode="before")
+    @classmethod
+    def _none_to_empty_list(cls, value: Any) -> Any:
+        return [] if value is None else value
+
+
+class TfPolicySetOutcomeListOptions(BaseModel):
+    """Options for listing tf-policy set outcomes under an evaluation."""
+
+    model_config = ConfigDict(populate_by_name=True, validate_by_name=True)
+
+    page_size: int | None = Field(None, alias="page[size]")
+    page_number: int | None = Field(None, alias="page[number]")
+    # Wire params: filter[<key>][status] and filter[<key>][enforcement_level]
+    # Build these at the resource layer via build_filter_params().
+    filter_status: str | None = None
+    filter_enforcement_level: str | None = None

--- a/src/pytfe/resources/tf_policy_evaluation.py
+++ b/src/pytfe/resources/tf_policy_evaluation.py
@@ -1,0 +1,209 @@
+# Copyright IBM Corp. 2025, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+from __future__ import annotations
+
+import builtins
+from collections.abc import Iterator
+from typing import Any
+
+from .._jsonapi import attach_jsonapi
+from ..errors import (
+    InvalidRunIDError,
+    InvalidTfPolicyEvaluationIDError,
+)
+from ..models.tf_policy_evaluation import (
+    TfPolicyEvaluation,
+    TfPolicyEvaluationListOptions,
+    TfPolicyEvaluationOverrideOptions,
+)
+from ..models.tf_policy_set_outcome import (
+    TfPolicySetOutcome,
+    TfPolicySetOutcomeListOptions,
+)
+from ..utils import valid_string_id
+from ._base import _Service
+
+
+class TfPolicyEvaluations(_Service):
+    """tf-policy evaluation methods for the HCP Terraform / TFE API."""
+
+    def list(
+        self,
+        run_id: str,
+        options: TfPolicyEvaluationListOptions | None = None,
+    ) -> Iterator[TfPolicyEvaluation]:
+        """List tf-policy evaluations for a run.
+
+        Args:
+            run_id: The run ID (e.g. ``"run-xxxxxxxx"``).
+            options: Optional pagination and include settings, as a
+                :class:`TfPolicyEvaluationListOptions`.
+
+        Returns:
+            A single-use ``Iterator[TfPolicyEvaluation]``. Wrap with ``list(...)``
+            to materialize or iterate more than once.
+
+        Raises:
+            InvalidRunIDError: If ``run_id`` is not a valid resource ID.
+            TFEError: If the API request fails.
+
+        Example:
+            >>> for evaluation in client.tf_policy_evaluations.list("run-abc123"):
+            ...     print(evaluation.id, evaluation.status)
+        """
+        if not valid_string_id(run_id):
+            raise InvalidRunIDError()
+        params = options.model_dump(by_alias=True, exclude_none=True) if options else {}
+        path = f"/api/v2/runs/{run_id}/tf-policy-evaluations"
+        for item in self._list(path, params=params):
+            yield self._tf_policy_evaluation_from(item)
+
+    def read(
+        self,
+        tf_policy_evaluation_id: str,
+        options: TfPolicyEvaluationListOptions | None = None,
+    ) -> TfPolicyEvaluation:
+        """Read a single tf-policy evaluation by ID.
+
+        Args:
+            tf_policy_evaluation_id: The evaluation ID (e.g. ``"tfpeval-xxxxxxxx"``).
+            options: Optional include settings (e.g. ``include="tf_policy_set_outcomes"``),
+                as a :class:`TfPolicyEvaluationListOptions`.
+
+        Returns:
+            The :class:`TfPolicyEvaluation`.
+
+        Raises:
+            InvalidTfPolicyEvaluationIDError: If ``tf_policy_evaluation_id`` is not a
+                valid resource ID.
+            TFEError: If the API request fails.
+
+        Example:
+            >>> evaluation = client.tf_policy_evaluations.read("tfpeval-abc123")
+            >>> print(evaluation.status)
+        """
+        if not valid_string_id(tf_policy_evaluation_id):
+            raise InvalidTfPolicyEvaluationIDError()
+        params = options.model_dump(by_alias=True, exclude_none=True) if options else {}
+        path = f"/api/v2/tf-policy-evaluations/{tf_policy_evaluation_id}"
+        r = self.t.request("GET", path, params=params)
+        data = r.json().get("data", {})
+        included = r.json().get("included")
+        return self._tf_policy_evaluation_from(data, included=included)
+
+    def override(
+        self,
+        tf_policy_evaluation_id: str,
+        options: TfPolicyEvaluationOverrideOptions | None = None,
+    ) -> TfPolicyEvaluation:
+        """Override a tf-policy evaluation that is in ``awaiting_override`` status.
+
+        The override action transitions the evaluation to ``overridden`` and
+        unblocks the run. Only valid when ``actions.is-overridable`` is ``true``.
+
+        Args:
+            tf_policy_evaluation_id: The evaluation ID (e.g. ``"tfpeval-xxxxxxxx"``).
+            options: Optional override comment, as a
+                :class:`TfPolicyEvaluationOverrideOptions`.
+
+        Returns:
+            The updated :class:`TfPolicyEvaluation`
+
+        Raises:
+            InvalidTfPolicyEvaluationIDError: If ``tf_policy_evaluation_id`` is not a
+                valid resource ID.
+            TFEError: If the API request fails (including state-transition errors when
+                the evaluation is not in ``awaiting_override``).
+
+        Example:
+            >>> result = client.tf_policy_evaluations.override(
+            ...     "tfpeval-abc123",
+            ...     TfPolicyEvaluationOverrideOptions(comment="approved by ops"),
+            ... )
+            >>> print(result.status)
+        """
+        if not valid_string_id(tf_policy_evaluation_id):
+            raise InvalidTfPolicyEvaluationIDError()
+        body = options.model_dump(exclude_none=True) if options else {}
+        path = (
+            f"/api/v2/tf-policy-evaluations/{tf_policy_evaluation_id}/actions/override"
+        )
+        r = self.t.request("POST", path, json_body=body)
+        data = r.json().get("data", {})
+        return self._tf_policy_evaluation_from(data)
+
+    def list_set_outcomes(
+        self,
+        tf_policy_evaluation_id: str,
+        options: TfPolicySetOutcomeListOptions | None = None,
+    ) -> Iterator[TfPolicySetOutcome]:
+        """List tf-policy set outcomes nested under a tf-policy evaluation.
+
+        Args:
+            tf_policy_evaluation_id: The evaluation ID (e.g. ``"tfpeval-xxxxxxxx"``).
+            options: Optional pagination and filter settings, as a
+                :class:`TfPolicySetOutcomeListOptions`.
+
+        Returns:
+            A single-use ``Iterator[TfPolicySetOutcome]``. Wrap with ``list(...)``
+            to materialize or iterate more than once.
+
+        Raises:
+            InvalidTfPolicyEvaluationIDError: If ``tf_policy_evaluation_id`` is not a
+                valid resource ID.
+            TFEError: If the API request fails.
+
+        Example:
+            >>> for outcome in client.tf_policy_evaluations.list_set_outcomes(
+            ...     "tfpeval-abc123",
+            ...     TfPolicySetOutcomeListOptions(filter_status="failed"),
+            ... ):
+            ...     print(outcome.id, outcome.policy_set_name)
+        """
+        if not valid_string_id(tf_policy_evaluation_id):
+            raise InvalidTfPolicyEvaluationIDError()
+        params: dict[str, Any] = {}
+        if options:
+            page_params = options.model_dump(
+                by_alias=True,
+                exclude_none=True,
+                include={"page_size", "page_number"},
+            )
+            params.update(page_params)
+            filter_params = _build_filter_params(options)
+            params.update(filter_params)
+        path = f"/api/v2/tf-policy-evaluations/{tf_policy_evaluation_id}/tf-policy-set-outcomes"
+        for item in self._list(path, params=params):
+            yield _tf_policy_set_outcome_from(item)
+
+    # ── Helpers ──────────────────────────────────────────────────────────────
+
+    def _tf_policy_evaluation_from(
+        self,
+        data: dict[str, Any],
+        included: builtins.list[dict[str, Any]] | None = None,
+    ) -> TfPolicyEvaluation:
+        """Convert an API data object to a :class:`TfPolicyEvaluation`."""
+        attrs = dict(data.get("attributes") or {})
+        attrs["id"] = data.get("id")
+        model = TfPolicyEvaluation.model_validate(attrs)
+        return attach_jsonapi(model, data, included)
+
+
+def _tf_policy_set_outcome_from(data: dict[str, Any]) -> TfPolicySetOutcome:
+    """Convert an API data object to a :class:`TfPolicySetOutcome`."""
+    attrs = dict(data.get("attributes") or {})
+    attrs["id"] = data.get("id")
+    model = TfPolicySetOutcome.model_validate(attrs)
+    return attach_jsonapi(model, data)
+
+
+def _build_filter_params(options: TfPolicySetOutcomeListOptions) -> dict[str, str]:
+    """Build ``filter[...]`` query parameters from list options."""
+    result: dict[str, str] = {}
+    if options.filter_status is not None:
+        result["filter[outcomes][status]"] = options.filter_status
+    if options.filter_enforcement_level is not None:
+        result["filter[outcomes][enforcement_level]"] = options.filter_enforcement_level
+    return result

--- a/src/pytfe/resources/tf_policy_set_outcome.py
+++ b/src/pytfe/resources/tf_policy_set_outcome.py
@@ -1,0 +1,49 @@
+# Copyright IBM Corp. 2025, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+from __future__ import annotations
+
+from typing import Any
+
+from .._jsonapi import attach_jsonapi
+from ..errors import InvalidTfPolicySetOutcomeIDError
+from ..models.tf_policy_set_outcome import TfPolicySetOutcome
+from ..utils import valid_string_id
+from ._base import _Service
+
+
+class TfPolicySetOutcomes(_Service):
+    """tf-policy set outcome methods for the HCP Terraform / TFE API."""
+
+    def read(self, tf_policy_set_outcome_id: str) -> TfPolicySetOutcome:
+        """Read a tf-policy set outcome by ID.
+
+        Args:
+            tf_policy_set_outcome_id: The set outcome ID (e.g. ``"tfpsout-xxxxxxxx"``).
+
+        Returns:
+            The :class:`TfPolicySetOutcome`.
+
+        Raises:
+            InvalidTfPolicySetOutcomeIDError: If ``tf_policy_set_outcome_id`` is not a
+                valid resource ID.
+            TFEError: If the API request fails.
+
+        Example:
+            >>> outcome = client.tf_policy_set_outcomes.read("tfpsout-abc123")
+            >>> for o in outcome.outcomes:
+            ...     print(o.policy_name, o.enforcement_level, o.status)
+        """
+        if not valid_string_id(tf_policy_set_outcome_id):
+            raise InvalidTfPolicySetOutcomeIDError()
+        path = f"/api/v2/tf-policy-set-outcomes/{tf_policy_set_outcome_id}"
+        r = self.t.request("GET", path)
+        data = r.json().get("data", {})
+        return _tf_policy_set_outcome_from(data)
+
+
+def _tf_policy_set_outcome_from(data: dict[str, Any]) -> TfPolicySetOutcome:
+    attrs = dict(data.get("attributes") or {})
+    attrs["id"] = data.get("id")
+    model = TfPolicySetOutcome.model_validate(attrs)
+    return attach_jsonapi(model, data)

--- a/tests/units/test_tf_policy_evaluation.py
+++ b/tests/units/test_tf_policy_evaluation.py
@@ -1,0 +1,317 @@
+# Copyright IBM Corp. 2025, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+"""Unit tests for TfPolicyEvaluations resource."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from pytfe._http import HTTPTransport
+from pytfe.errors import (
+    InvalidRunIDError,
+    InvalidTfPolicyEvaluationIDError,
+)
+from pytfe.models.policy_types import TfPolicyEvaluationStatus, TfPolicyStage
+from pytfe.models.tf_policy_evaluation import (
+    TfPolicyEvaluation,
+    TfPolicyEvaluationListOptions,
+    TfPolicyEvaluationOverrideOptions,
+)
+from pytfe.models.tf_policy_set_outcome import (
+    TfPolicySetOutcome,
+    TfPolicySetOutcomeListOptions,
+)
+from pytfe.resources.tf_policy_evaluation import TfPolicyEvaluations
+
+_EVAL_ID = "tfpeval-abc123"
+_RUN_ID = "run-abc123"
+
+
+class TestTfPolicyEvaluations:
+    """Tests for the TfPolicyEvaluations service."""
+
+    @pytest.fixture
+    def mock_transport(self):
+        return Mock(spec=HTTPTransport)
+
+    @pytest.fixture
+    def service(self, mock_transport):
+        return TfPolicyEvaluations(mock_transport)
+
+    @pytest.fixture
+    def eval_api_data(self):
+        """Minimal evaluation API data object."""
+        return {
+            "id": _EVAL_ID,
+            "type": "tf-policy-evaluations",
+            "attributes": {
+                "status": "passed",
+                "stage-type": "Plan",
+                "result-count": {
+                    "advisory-failed": 0,
+                    "mandatory-failed": 0,
+                    "passed": 3,
+                    "errored": 0,
+                    "unknown": 0,
+                },
+            },
+            "relationships": {
+                "run": {"data": {"id": _RUN_ID, "type": "runs"}},
+            },
+        }
+
+    @pytest.fixture
+    def awaiting_override_data(self):
+        """Evaluation data in awaiting_override status."""
+        return {
+            "id": _EVAL_ID,
+            "type": "tf-policy-evaluations",
+            "attributes": {
+                "status": "awaiting_override",
+                "stage-type": "Plan",
+                "actions": {"is-overridable": True},
+                "permissions": {"can-override": True},
+            },
+        }
+
+    # ── Model tests ──────────────────────────────────────────────────────────
+
+    def test_evaluation_model_fields(self, eval_api_data):
+        """TfPolicyEvaluation parses id, status, and stage-type."""
+        attrs = {**eval_api_data["attributes"], "id": eval_api_data["id"]}
+        model = TfPolicyEvaluation.model_validate(attrs)
+        assert model.id == _EVAL_ID
+        assert model.status == TfPolicyEvaluationStatus.PASSED
+        assert model.stage_type == TfPolicyStage.PLAN
+
+    def test_evaluation_result_count(self, eval_api_data):
+        """result_count sub-model parsed correctly."""
+        attrs = {**eval_api_data["attributes"], "id": eval_api_data["id"]}
+        model = TfPolicyEvaluation.model_validate(attrs)
+        assert model.result_count is not None
+        assert model.result_count.passed == 3
+        assert model.result_count.mandatory_failed == 0
+
+    def test_list_options_serializes(self):
+        """TfPolicyEvaluationListOptions serialises page params with alias."""
+        opts = TfPolicyEvaluationListOptions(page_size=20)
+        dumped = opts.model_dump(by_alias=True, exclude_none=True)
+        assert dumped == {"page[size]": 20}
+
+    def test_override_options_serializes(self):
+        """TfPolicyEvaluationOverrideOptions serialises comment."""
+        opts = TfPolicyEvaluationOverrideOptions(comment="approved")
+        dumped = opts.model_dump(exclude_none=True)
+        assert dumped == {"comment": "approved"}
+
+    def test_override_options_no_comment(self):
+        """TfPolicyEvaluationOverrideOptions with no comment dumps to empty dict."""
+        opts = TfPolicyEvaluationOverrideOptions()
+        assert opts.model_dump(exclude_none=True) == {}
+
+    # ── Parser tests ─────────────────────────────────────────────────────────
+
+    def test_tf_policy_evaluation_from(self, service, eval_api_data):
+        """_tf_policy_evaluation_from builds TfPolicyEvaluation from API data."""
+        result = service._tf_policy_evaluation_from(eval_api_data)
+        assert isinstance(result, TfPolicyEvaluation)
+        assert result.id == _EVAL_ID
+        assert result.status == TfPolicyEvaluationStatus.PASSED
+
+    def test_tf_policy_evaluation_from_missing_attrs(self, service):
+        """_tf_policy_evaluation_from handles missing attributes gracefully."""
+        data = {"id": _EVAL_ID, "attributes": {}}
+        result = service._tf_policy_evaluation_from(data)
+        assert result.id == _EVAL_ID
+        assert result.status is None
+
+    # ── list() tests ─────────────────────────────────────────────────────────
+
+    def test_list_success(self, service, eval_api_data):
+        """list() yields TfPolicyEvaluation objects for each API item."""
+        service._list = Mock(return_value=[eval_api_data])
+
+        results = list(service.list(_RUN_ID))
+
+        service._list.assert_called_once_with(
+            f"/api/v2/runs/{_RUN_ID}/tf-policy-evaluations", params={}
+        )
+        assert len(results) == 1
+        assert isinstance(results[0], TfPolicyEvaluation)
+        assert results[0].id == _EVAL_ID
+
+    def test_list_with_options(self, service, eval_api_data):
+        """list() forwards page params from options."""
+        service._list = Mock(return_value=[eval_api_data])
+        opts = TfPolicyEvaluationListOptions(page_size=5)
+
+        list(service.list(_RUN_ID, options=opts))
+
+        _, kwargs = service._list.call_args
+        assert kwargs["params"]["page[size]"] == 5
+
+    def test_list_empty(self, service):
+        """list() returns empty iterator when no evaluations exist."""
+        service._list = Mock(return_value=[])
+        assert list(service.list(_RUN_ID)) == []
+
+    def test_list_invalid_run_id(self, service):
+        """list() raises InvalidRunIDError for a bad run ID."""
+        with pytest.raises(InvalidRunIDError):
+            list(service.list("not valid!"))
+
+    def test_list_empty_run_id(self, service):
+        """list() raises InvalidRunIDError for an empty run ID."""
+        with pytest.raises(InvalidRunIDError):
+            list(service.list(""))
+
+    # ── read() tests ─────────────────────────────────────────────────────────
+
+    def test_read_success(self, service, mock_transport, eval_api_data):
+        """read() GETs the correct path and returns TfPolicyEvaluation."""
+        mock_response = Mock()
+        mock_response.json.return_value = {"data": eval_api_data}
+        mock_transport.request.return_value = mock_response
+
+        result = service.read(_EVAL_ID)
+
+        mock_transport.request.assert_called_once_with(
+            "GET", f"/api/v2/tf-policy-evaluations/{_EVAL_ID}", params={}
+        )
+        assert isinstance(result, TfPolicyEvaluation)
+        assert result.id == _EVAL_ID
+
+    def test_read_with_include(self, service, mock_transport, eval_api_data):
+        """read() forwards include param when set in options."""
+        mock_response = Mock()
+        mock_response.json.return_value = {"data": eval_api_data, "included": []}
+        mock_transport.request.return_value = mock_response
+
+        opts = TfPolicyEvaluationListOptions(include="tf_policy_set_outcomes")
+        service.read(_EVAL_ID, options=opts)
+
+        _, kwargs = mock_transport.request.call_args
+        assert kwargs["params"]["include"] == "tf_policy_set_outcomes"
+
+    def test_read_invalid_id(self, service):
+        """read() raises InvalidTfPolicyEvaluationIDError for a bad ID."""
+        with pytest.raises(InvalidTfPolicyEvaluationIDError):
+            service.read("not valid!")
+
+    def test_read_empty_id(self, service):
+        """read() raises InvalidTfPolicyEvaluationIDError for an empty ID."""
+        with pytest.raises(InvalidTfPolicyEvaluationIDError):
+            service.read("")
+
+    # ── override() tests ─────────────────────────────────────────────────────
+
+    def test_override_success(self, service, mock_transport, awaiting_override_data):
+        """override() POSTs to the correct path and returns TfPolicyEvaluation."""
+        overridden = dict(awaiting_override_data)
+        overridden["attributes"] = {
+            **awaiting_override_data["attributes"],
+            "status": "overridden",
+        }
+        mock_response = Mock()
+        mock_response.json.return_value = {"data": overridden}
+        mock_transport.request.return_value = mock_response
+
+        result = service.override(
+            _EVAL_ID, TfPolicyEvaluationOverrideOptions(comment="ops approved")
+        )
+
+        mock_transport.request.assert_called_once_with(
+            "POST",
+            f"/api/v2/tf-policy-evaluations/{_EVAL_ID}/actions/override",
+            json_body={"comment": "ops approved"},
+        )
+        assert isinstance(result, TfPolicyEvaluation)
+        assert result.status == TfPolicyEvaluationStatus.OVERRIDDEN
+
+    def test_override_no_comment(self, service, mock_transport, awaiting_override_data):
+        """override() sends empty body when no comment provided."""
+        mock_response = Mock()
+        mock_response.json.return_value = {"data": awaiting_override_data}
+        mock_transport.request.return_value = mock_response
+
+        service.override(_EVAL_ID)
+
+        _, kwargs = mock_transport.request.call_args
+        assert kwargs["json_body"] == {}
+
+    def test_override_invalid_id(self, service):
+        """override() raises InvalidTfPolicyEvaluationIDError for a bad ID."""
+        with pytest.raises(InvalidTfPolicyEvaluationIDError):
+            service.override("not valid!")
+
+    def test_override_empty_id(self, service):
+        """override() raises InvalidTfPolicyEvaluationIDError for an empty ID."""
+        with pytest.raises(InvalidTfPolicyEvaluationIDError):
+            service.override("")
+
+    # ── list_set_outcomes() tests ────────────────────────────────────────────
+
+    @pytest.fixture
+    def set_outcome_api_data(self):
+        """Minimal TfPolicySetOutcome API data object."""
+        return {
+            "id": "tfpsout-xyz789",
+            "type": "tf-policy-set-outcomes",
+            "attributes": {
+                "policy-set-name": "my-policy-set",
+                "overridable": True,
+                "outcomes": [],
+            },
+        }
+
+    def test_list_set_outcomes_success(self, service, set_outcome_api_data):
+        """list_set_outcomes() yields TfPolicySetOutcome objects."""
+        service._list = Mock(return_value=[set_outcome_api_data])
+
+        results = list(service.list_set_outcomes(_EVAL_ID))
+
+        service._list.assert_called_once_with(
+            f"/api/v2/tf-policy-evaluations/{_EVAL_ID}/tf-policy-set-outcomes",
+            params={},
+        )
+        assert len(results) == 1
+        assert isinstance(results[0], TfPolicySetOutcome)
+        assert results[0].id == "tfpsout-xyz789"
+
+    def test_list_set_outcomes_with_filter(self, service, set_outcome_api_data):
+        """list_set_outcomes() builds filter params from options."""
+        service._list = Mock(return_value=[set_outcome_api_data])
+        opts = TfPolicySetOutcomeListOptions(filter_status="failed")
+
+        list(service.list_set_outcomes(_EVAL_ID, options=opts))
+
+        _, kwargs = service._list.call_args
+        assert kwargs["params"]["filter[outcomes][status]"] == "failed"
+
+    def test_list_set_outcomes_enforcement_level_filter(
+        self, service, set_outcome_api_data
+    ):
+        """list_set_outcomes() builds enforcement_level filter param."""
+        service._list = Mock(return_value=[set_outcome_api_data])
+        opts = TfPolicySetOutcomeListOptions(
+            filter_enforcement_level="mandatory_overridable"
+        )
+
+        list(service.list_set_outcomes(_EVAL_ID, options=opts))
+
+        _, kwargs = service._list.call_args
+        assert (
+            kwargs["params"]["filter[outcomes][enforcement_level]"]
+            == "mandatory_overridable"
+        )
+
+    def test_list_set_outcomes_invalid_id(self, service):
+        """list_set_outcomes() raises InvalidTfPolicyEvaluationIDError for a bad ID."""
+        with pytest.raises(InvalidTfPolicyEvaluationIDError):
+            list(service.list_set_outcomes("not valid!"))
+
+    def test_list_set_outcomes_empty_id(self, service):
+        """list_set_outcomes() raises InvalidTfPolicyEvaluationIDError for an empty ID."""
+        with pytest.raises(InvalidTfPolicyEvaluationIDError):
+            list(service.list_set_outcomes(""))

--- a/tests/units/test_tf_policy_set_outcome.py
+++ b/tests/units/test_tf_policy_set_outcome.py
@@ -1,0 +1,230 @@
+# Copyright IBM Corp. 2025, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+"""Unit tests for TfPolicySetOutcomes resource."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from pytfe._http import HTTPTransport
+from pytfe.errors import InvalidTfPolicySetOutcomeIDError
+from pytfe.models.policy_types import TfPolicyEnforcementLevel, TfPolicyEvaluationStatus
+from pytfe.models.tf_policy_set_outcome import (
+    PassedResource,
+    PolicyOutcome,
+    TfPolicySetOutcome,
+    TfPolicySetOutcomeListOptions,
+    TraversalValue,
+)
+from pytfe.resources.tf_policy_set_outcome import TfPolicySetOutcomes
+
+_OUTCOME_ID = "tfpsout-abc123"
+
+
+class TestTfPolicySetOutcomes:
+    """Tests for the TfPolicySetOutcomes service."""
+
+    @pytest.fixture
+    def mock_transport(self):
+        return Mock(spec=HTTPTransport)
+
+    @pytest.fixture
+    def service(self, mock_transport):
+        return TfPolicySetOutcomes(mock_transport)
+
+    @pytest.fixture
+    def outcome_api_data(self):
+        """Minimal set-outcome API data object."""
+        return {
+            "id": _OUTCOME_ID,
+            "type": "tf-policy-set-outcomes",
+            "attributes": {
+                "policy-set-name": "security-baseline",
+                "policy-set-description": "Baseline security policies",
+                "overridable": True,
+                "error": None,
+                "result-count": {
+                    "advisory-failed": 0,
+                    "mandatory-failed": 1,
+                    "passed": 2,
+                    "errored": 0,
+                    "unknown": 0,
+                },
+                # Inner outcomes use snake_case (stored verbatim, not dash-transformed).
+                "outcomes": [
+                    {
+                        "policy_name": "require-tags",
+                        "enforcement_level": "mandatory_overridable",
+                        "status": "failed",
+                        "file_name": "policies/require-tags.tf",
+                        "description": "Resources must have required tags",
+                        "diagnostics": [],
+                        "passed_resources": [],
+                    }
+                ],
+            },
+            "relationships": {
+                "tf-policy-evaluation": {
+                    "data": {"id": "tfpeval-xyz", "type": "tf-policy-evaluations"}
+                }
+            },
+        }
+
+    # ── Model tests ──────────────────────────────────────────────────────────
+
+    def test_outcome_model_fields(self, outcome_api_data):
+        """TfPolicySetOutcome parses id, name, and overridable."""
+        attrs = {**outcome_api_data["attributes"], "id": outcome_api_data["id"]}
+        model = TfPolicySetOutcome.model_validate(attrs)
+        assert model.id == _OUTCOME_ID
+        assert model.policy_set_name == "security-baseline"
+        assert model.overridable is True
+
+    def test_outcome_result_count(self, outcome_api_data):
+        """result_count sub-model parses mandatory_failed."""
+        attrs = {**outcome_api_data["attributes"], "id": outcome_api_data["id"]}
+        model = TfPolicySetOutcome.model_validate(attrs)
+        assert model.result_count is not None
+        assert model.result_count.mandatory_failed == 1
+
+    def test_snake_case_outcomes_parse(self, outcome_api_data):
+        """Inner outcomes array uses snake_case keys and parses without error.
+
+        Atlas stores outcomes verbatim (not dash-transformed). This test asserts
+        ``enforcement_level=mandatory_overridable`` survives round-trip.
+        """
+        attrs = {**outcome_api_data["attributes"], "id": outcome_api_data["id"]}
+        model = TfPolicySetOutcome.model_validate(attrs)
+
+        assert len(model.outcomes) == 1
+        outcome = model.outcomes[0]
+        assert outcome.policy_name == "require-tags"
+        assert (
+            outcome.enforcement_level == TfPolicyEnforcementLevel.MANDATORY_OVERRIDABLE
+        )
+        assert outcome.status == TfPolicyEvaluationStatus.FAILED
+
+    def test_mandatory_overridable_wire_value(self):
+        """TfPolicyEnforcementLevel.MANDATORY_OVERRIDABLE has underscore, not hyphen."""
+        assert (
+            TfPolicyEnforcementLevel.MANDATORY_OVERRIDABLE.value
+            == "mandatory_overridable"
+        )
+
+    def test_policy_outcome_model_diagnostics(self):
+        """PolicyOutcome.diagnostics sub-objects parse correctly."""
+        outcome = PolicyOutcome.model_validate(
+            {
+                "policy_name": "test-policy",
+                "enforcement_level": "mandatory",
+                "status": "failed",
+                "diagnostics": [
+                    {
+                        "code": "E001",
+                        "summary": "tag missing",
+                        "resources": [
+                            {
+                                "resource_name": "aws_instance.web",
+                                "error_message": "missing tag Environment",
+                                "values": [
+                                    {
+                                        "traversal": "aws_instance.web.tags",
+                                        "statement": "{}",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+        assert len(outcome.diagnostics) == 1
+        diag = outcome.diagnostics[0]
+        assert diag.code == "E001"
+        assert len(diag.resources) == 1
+        resource = diag.resources[0]
+        assert resource.resource_name == "aws_instance.web"
+        assert len(resource.values) == 1
+        assert resource.values[0].traversal == "aws_instance.web.tags"
+
+    def test_passed_resource_parses(self):
+        """PassedResource model parses resource_name and info_messages."""
+        pr = PassedResource.model_validate(
+            {
+                "resource_name": "aws_instance.app",
+                "info_messages": ["all tags present"],
+            }
+        )
+        assert pr.resource_name == "aws_instance.app"
+        assert pr.info_messages == ["all tags present"]
+
+    def test_list_options_filter_fields(self):
+        """TfPolicySetOutcomeListOptions accepts filter fields."""
+        opts = TfPolicySetOutcomeListOptions(
+            filter_status="failed",
+            filter_enforcement_level="mandatory_overridable",
+        )
+        assert opts.filter_status == "failed"
+        assert opts.filter_enforcement_level == "mandatory_overridable"
+
+    def test_traversal_value_parses(self):
+        """TraversalValue model parses traversal and statement."""
+        tv = TraversalValue.model_validate(
+            {"traversal": "var.tags", "statement": '{"env": "prod"}'}
+        )
+        assert tv.traversal == "var.tags"
+        assert tv.statement == '{"env": "prod"}'
+
+    # ── Parser tests ─────────────────────────────────────────────────────────
+
+    def test_read_success(self, service, mock_transport, outcome_api_data):
+        """read() GETs the correct path and returns TfPolicySetOutcome."""
+        mock_response = Mock()
+        mock_response.json.return_value = {"data": outcome_api_data}
+        mock_transport.request.return_value = mock_response
+
+        result = service.read(_OUTCOME_ID)
+
+        mock_transport.request.assert_called_once_with(
+            "GET", f"/api/v2/tf-policy-set-outcomes/{_OUTCOME_ID}"
+        )
+        assert isinstance(result, TfPolicySetOutcome)
+        assert result.id == _OUTCOME_ID
+        assert result.policy_set_name == "security-baseline"
+
+    def test_read_outcome_with_snake_case_outcomes(
+        self, service, mock_transport, outcome_api_data
+    ):
+        """read() correctly parses inner snake_case outcomes array."""
+        mock_response = Mock()
+        mock_response.json.return_value = {"data": outcome_api_data}
+        mock_transport.request.return_value = mock_response
+
+        result = service.read(_OUTCOME_ID)
+
+        assert len(result.outcomes) == 1
+        assert (
+            result.outcomes[0].enforcement_level
+            == TfPolicyEnforcementLevel.MANDATORY_OVERRIDABLE
+        )
+
+    def test_read_invalid_id(self, service):
+        """read() raises InvalidTfPolicySetOutcomeIDError for a bad ID."""
+        with pytest.raises(InvalidTfPolicySetOutcomeIDError):
+            service.read("not valid!")
+
+    def test_read_empty_id(self, service):
+        """read() raises InvalidTfPolicySetOutcomeIDError for an empty ID."""
+        with pytest.raises(InvalidTfPolicySetOutcomeIDError):
+            service.read("")
+
+    def test_read_null_error_field(self, service, mock_transport, outcome_api_data):
+        """read() handles null error field gracefully."""
+        outcome_api_data["attributes"]["error"] = None
+        mock_response = Mock()
+        mock_response.json.return_value = {"data": outcome_api_data}
+        mock_transport.request.return_value = mock_response
+
+        result = service.read(_OUTCOME_ID)
+        assert result.error is None


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/python-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->

### Add tf-policy support: evaluations, set outcomes, and PolicyKind.TFPOLICY
#### Summary
Adds SDK support for tf-policy — HCP Terraform's native policy-as-code engine (distinct from Sentinel and OPA) — so callers can read a run's compliance posture, inspect per-policy diagnostics, override mandatory_overridable failures, and create/manage kind=tfpolicy policy sets. This is the SDK-side prerequisite for the hashicorp.terraform Ansible collection's planned tf-policy modules (pre-flight compliance gate, override action, policy-set lifecycle).

Every code path in this PR has been verified against a live HCP Terraform org, end to end, including driving a real evaluation through AWAITING_OVERRIDE → OVERRIDDEN — not just unit-tested against mocks. See "Live verification" below.

#### What's new
**client.tf_policy_evaluations (src/pytfe/resources/tf_policy_evaluation.py)**

```
list(run_id, options=None) → Iterator[TfPolicyEvaluation] — GET /runs/{run_id}/tf-policy-evaluations
read(tf_policy_evaluation_id, options=None) → TfPolicyEvaluation — GET /tf-policy-evaluations/{id}; pass TfPolicyEvaluationListOptions(include="tf_policy_set_outcomes") to sideload outcomes in one round trip
override(tf_policy_evaluation_id, options=None) → TfPolicyEvaluation — POST /tf-policy-evaluations/{id}/actions/override; transitions awaiting_override → overridden
list_set_outcomes(tf_policy_evaluation_id, options=None) → Iterator[TfPolicySetOutcome] — GET /tf-policy-evaluations/{id}/tf-policy-set-outcomes; supports filter_status / filter_enforcement_level
```

**client.tf_policy_set_outcomes (src/pytfe/resources/tf_policy_set_outcome.py)**

```
read(tf_policy_set_outcome_id) → TfPolicySetOutcome — GET /tf-policy-set-outcomes/{id}, top-level lookup independent of the parent evaluation
```

**New models (src/pytfe/models/tf_policy_evaluation.py, tf_policy_set_outcome.py)**

```
TfPolicyEvaluation + TfPolicyEvaluationStatusTimestamps, TfPolicyResultCount, TfPolicyEvaluationError, TfPolicyEvaluationPermissions, TfPolicyEvaluationActions
TfPolicySetOutcome + PolicyOutcome, Diagnostic, OutcomeResource, TraversalValue, PassedResource
TfPolicyEvaluationListOptions, TfPolicyEvaluationOverrideOptions, TfPolicySetOutcomeListOptions
```

**New enums (src/pytfe/models/policy_types.py)**

```
PolicyKind.TFPOLICY = "tfpolicy" — plugs into the existing client.policy_sets CRUD, no new policy-set resource needed
TfPolicyEvaluationStatus, TfPolicyStage, TfPolicyEnforcementLevel
```

**New errors (src/pytfe/errors.py)**

`InvalidTfPolicyEvaluationIDError, InvalidTfPolicySetOutcomeIDError`

**Docs & examples**

- docs/scenarios/tf-policy-evaluation.md — new scenario doc, matches the existing docs/scenarios/*.md format
- examples/tf_policy_evaluation.py — runnable CLI demo (--run-id, --read, --override, --dry-run)

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

[JIRA](https://hashicorp.atlassian.net/browse/TF-39902)

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->

## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).
