### PR TITLE
Release 1.4.1: fix missing tf_policy_checked/tf_policy_override RunStatus values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Unreleased
 
 # Released
+# v1.4.1
+
+## Bug Fixes
+
+* Added the `tf_policy_checked` and `tf_policy_override` values to `RunStatus`. A run
+  paused awaiting a tf-policy override decision reports `status: "tf_policy_override"`
+  on the wire; without this fix, `client.runs.read()` (and anything that parses a `Run`
+  through this status) raised a validation error instead of returning the run.
+  Discovered via live testing of the `hashicorp.terraform` Ansible collection's
+  tf-policy modules — no mocked unit fixture had exercised this status before.
+
 # v1.4.0
 
 ## Enhancements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pytfe"
-version = "1.4.0"
+version = "1.4.1"
 description = "Official Python SDK for HashiCorp Terraform Cloud / Terraform Enterprise (TFE) API v2"
 readme = "README.md"
 license = { text = "MPL-2.0" }

--- a/src/pytfe/models/run.py
+++ b/src/pytfe/models/run.py
@@ -70,6 +70,8 @@ class RunStatus(str, Enum):
     Run_Pre_Plan_Running = "pre_plan_running"
     Run_Queuing = "queuing"
     Run_Queuing_Apply = "queuing_apply"
+    Run_Tf_Policy_Checked = "tf_policy_checked"
+    Run_Tf_Policy_Override = "tf_policy_override"
 
 
 class RunIncludeOpt(str, Enum):

--- a/tests/units/test_run.py
+++ b/tests/units/test_run.py
@@ -523,3 +523,23 @@ class TestRuns:
             assert call_args[0][0] == "POST"
             assert call_args[0][1] == "/api/v2/runs/run-discard-123/actions/discard"
             assert call_args[1]["json_body"]["comment"] == "Discarding run"
+
+
+class TestRunStatusTfPolicy:
+    """Regression test: atlas introduced ``tf_policy_checked`` and
+    ``tf_policy_override`` run statuses alongside tf-policy (the analogues
+    of the pre-existing ``policy_checked``/``policy_override`` statuses for
+    the Sentinel/OPA flow). A run that pauses awaiting a tf-policy override
+    decision reports ``status: "tf_policy_override"`` on the wire - if the
+    enum doesn't know that value, parsing the run raises a validation error
+    instead of returning the status. Caught only by live testing against a
+    run that actually reached this status; no mocked fixture exercised it.
+    """
+
+    def test_tf_policy_override_status_parses(self):
+        run = Run.model_validate({"id": "run-abc123", "status": "tf_policy_override"})
+        assert run.status == RunStatus.Run_Tf_Policy_Override
+
+    def test_tf_policy_checked_status_parses(self):
+        run = Run.model_validate({"id": "run-abc123", "status": "tf_policy_checked"})
+        assert run.status == RunStatus.Run_Tf_Policy_Checked


### PR DESCRIPTION
## Summary
- `RunStatus` was missing `tf_policy_checked` and `tf_policy_override` — the tf-policy analogues of the pre-existing `policy_checked`/`policy_override` statuses. Atlas transitions a run to `tf_policy_override` when its plan-stage tf-policy evaluation pauses awaiting an override decision (`run.rb`: `transitions from: :planned, to: :tf_policy_override`).
- Without these values, `client.runs.read()`/`.list()` raised a pydantic `ValidationError` instead of returning the run, the moment a run's wire status became `tf_policy_override`.
- Confirmed go-tfe never had this gap: its `Runs_attributes_status` type is Kiota-generated from the OpenAPI spec, which already documents both values as public-beta. pytfe's `RunStatus` is hand-maintained and simply missed the addition.
- Found via live testing of the `hashicorp.terraform` Ansible collection's new tf-policy modules (`tf_policy_evaluation_info`, `tf_policy_evaluation`) against a real HCP Terraform run that reached this status — no mocked unit fixture had exercised it before.
- Bumps `pytfe` to 1.4.1.

## Test plan
- [x] Added regression tests (`TestRunStatusTfPolicy`) confirming both statuses parse correctly on the `Run` model.
- [x] `pytest tests/units` — 1179 passed.
- [x] `make lint` (ruff + mypy) — clean.
- [x] Verified live: a run that paused at `tf_policy_override` on `prab-sandbox02` now parses correctly with this fix installed, where it previously raised.