### PR TITLE
List projects filtered by key=value tags.

### DIFF
--- a/src/pytfe/models/project.py
+++ b/src/pytfe/models/project.py
@@ -48,6 +48,8 @@ class ProjectListOptions(BaseModel):
 
     # Optional: String used to filter results by complete project name
     name: str | None = None
+    # Optional: Tags used to filter results by key=value pairs
+    tags: dict[str, str] | None = None
     # Optional: Query string to search projects by names
     query: str | None = None
     # Optional: Include related resources

--- a/src/pytfe/resources/projects.py
+++ b/src/pytfe/resources/projects.py
@@ -160,6 +160,10 @@ class Projects(_Service):
                 params["q"] = options.query
             if options.name:
                 params["filter[names]"] = options.name
+            if options.tags:
+                for i, (tag_name, tag_value) in enumerate(options.tags.items()):
+                    params[f"filter[tagged][{i}][key]"] = _safe_str(tag_name)
+                    params[f"filter[tagged][{i}][value]"] = _safe_str(tag_value)
             if options.page_size:
                 params["page[size]"] = options.page_size
 

--- a/tests/units/test_project.py
+++ b/tests/units/test_project.py
@@ -10,6 +10,7 @@ from pytfe.models.project import (
     Project,
     ProjectAddTagBindingsOptions,
     ProjectCreateOptions,
+    ProjectListOptions,
     ProjectUpdateOptions,
     TagBinding,
 )
@@ -108,6 +109,51 @@ class TestProjects:
         # Verify the correct API path was used
         expected_path = f"/api/v2/organizations/{organization}/projects"
         self.projects_service._list.assert_called_once_with(expected_path)
+
+    def test_list_projects_by_tags_query_params_serialized_success(self):
+        """Test successful serialization of project list tag filter into query parameters."""
+        organization = "test-org"
+        expected_path = f"/api/v2/organizations/{organization}/projects"
+
+        # Mock the _list method so we can introspect the query parameters
+        self.projects_service._list = Mock(return_value=[])
+
+        # Call the method under test
+        list(
+            self.projects_service.list(
+                organization, options=ProjectListOptions(tags={"department": "five"})
+            )
+        )
+
+        self.projects_service._list.assert_called_once_with(
+            expected_path,
+            params={
+                "filter[tagged][0][key]": "department",
+                "filter[tagged][0][value]": "five",
+            },
+        )
+
+    def test_list_projects_by_name_query_params_serialized_success(self):
+        """Test successful serialization of project list name filter into query parameters."""
+        organization = "test-org"
+        expected_path = f"/api/v2/organizations/{organization}/projects"
+
+        # Mock the _list method so we can introspect the query parameters
+        self.projects_service._list = Mock(return_value=[])
+
+        # Call the method under test
+        list(
+            self.projects_service.list(
+                organization, options=ProjectListOptions(name="prj-456")
+            )
+        )
+
+        self.projects_service._list.assert_called_once_with(
+            expected_path,
+            params={
+                "filter[names]": "prj-456",
+            },
+        )
 
     def test_create_project_success(self):
         """Test successful project creation"""


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/python-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

The TFE project list api supports `filter[i][key/value]` query parameters, documented since v1.2.x and working since at least v202507-1.

Expose tag filter via new field in `ProjectListOptions`, and serialize it to query parameters in `Projects.list()`.

## Testing plan

Unittests added to ensure query parameters are serialized as expected.

```
tests/units/test_project.py::TestProjects::test_list_projects_by_tags_query_params_serialized_success PASSED
tests/units/test_project.py::TestProjects::test_list_projects_by_name_query_params_serialized_success PASSED
```

## External links

- https://developer.hashicorp.com/terraform/enterprise/api-docs/projects#list-projects

## Output from tests

Added 2 unittests.

Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->

## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).
